### PR TITLE
Improve lesson and student forms

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.compose.ui:ui-graphics"
+    implementation "androidx.compose.material:material-icons-extended"
     debugImplementation "androidx.compose.ui:ui-tooling"
     debugImplementation "androidx.compose.ui:ui-test-manifest"
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -1,6 +1,7 @@
 package gr.tsambala.tutorbilling.ui.lesson
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -15,8 +16,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.tsambala.tutorbilling.data.model.RateTypes
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -117,20 +120,63 @@ fun LessonScreen(
             }
 
             // Date input
+            var showDatePicker by remember { mutableStateOf(false) }
+            val datePickerState = rememberDatePickerState()
+            if (showDatePicker) {
+                DatePickerDialog(
+                    onDismissRequest = { showDatePicker = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            showDatePicker = false
+                            datePickerState.selectedDateMillis?.let { millis ->
+                                val date = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+                                viewModel.updateDate(date.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
+                            }
+                        }) { Text("OK") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+                    }
+                ) {
+                    DatePicker(state = datePickerState)
+                }
+            }
             OutlinedTextField(
                 value = uiState.date,
-                onValueChange = viewModel::updateDate,
-                label = { Text("Date (YYYY-MM-DD)") },
-                modifier = Modifier.fillMaxWidth(),
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Date") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showDatePicker = true },
                 singleLine = true
             )
 
             // Time input
+            var showTimePicker by remember { mutableStateOf(false) }
+            val timeState = rememberTimePickerState()
+            if (showTimePicker) {
+                TimePickerDialog(
+                    onDismissRequest = { showTimePicker = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            showTimePicker = false
+                            viewModel.updateStartTime("%02d:%02d".format(timeState.hour, timeState.minute))
+                        }) { Text("OK") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+                    }
+                ) { TimePicker(state = timeState) }
+            }
             OutlinedTextField(
                 value = uiState.startTime,
-                onValueChange = viewModel::updateStartTime,
-                label = { Text("Start Time (HH:MM)") },
-                modifier = Modifier.fillMaxWidth(),
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Start Time") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showTimePicker = true },
                 singleLine = true
             )
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,6 +21,9 @@ class LessonViewModel @Inject constructor(
     private val lessonDao: LessonDao,
     private val studentDao: StudentDao
 ) : ViewModel() {
+
+    private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+    private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
     private val studentId: String? = savedStateHandle.get<String>("studentId")
     private val lessonId: String? = savedStateHandle.get<String>("lessonId")
@@ -35,8 +39,8 @@ class LessonViewModel @Inject constructor(
             // Set default values for new lesson
             _uiState.update {
                 it.copy(
-                    date = LocalDate.now().toString(),
-                    startTime = LocalTime.now().withSecond(0).withNano(0).toString()
+                    date = LocalDate.now().format(dateFormatter),
+                    startTime = LocalTime.now().withSecond(0).withNano(0).format(timeFormatter)
                 )
             }
         }
@@ -67,7 +71,7 @@ class LessonViewModel @Inject constructor(
                     lesson?.let { l ->
                         _uiState.update { state ->
                             state.copy(
-                                date = l.date,
+                                date = LocalDate.parse(l.date).format(dateFormatter),
                                 startTime = l.startTime,
                                 durationMinutes = l.durationMinutes.toString(),
                                 notes = l.notes ?: "",
@@ -99,12 +103,12 @@ class LessonViewModel @Inject constructor(
     }
 
     private fun isValidDate(value: String): Boolean = try {
-        LocalDate.parse(value)
+        LocalDate.parse(value, dateFormatter)
         true
     } catch (_: Exception) { false }
 
     private fun isValidTime(value: String): Boolean = try {
-        LocalTime.parse(value)
+        LocalTime.parse(value, timeFormatter)
         true
     } catch (_: Exception) { false }
 
@@ -128,7 +132,7 @@ class LessonViewModel @Inject constructor(
                 if (lessonId == "new") {
                     val lesson = Lesson(
                         studentId = sId,
-                        date = state.date,
+                        date = LocalDate.parse(state.date, dateFormatter).toString(),
                         startTime = state.startTime,
                         durationMinutes = duration,
                         notes = state.notes.ifBlank { null }
@@ -139,7 +143,7 @@ class LessonViewModel @Inject constructor(
                         val lesson = Lesson(
                             id = lId,
                             studentId = sId,
-                            date = state.date,
+                            date = LocalDate.parse(state.date, dateFormatter).toString(),
                             startTime = state.startTime,
                             durationMinutes = duration,
                             notes = state.notes.ifBlank { null }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -384,6 +384,12 @@ private fun StudentEditForm(
     onCancel: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val nameError = uiState.name.isBlank()
+    val surnameError = uiState.surname.isBlank()
+    val phoneError = !viewModel.isPhoneValid(uiState.parentMobile)
+    val emailError = !viewModel.isEmailValid(uiState.parentEmail)
+    val rateError = uiState.rate.toDoubleOrNull() == null
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -393,7 +399,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.name,
             onValueChange = viewModel::updateName,
-            label = { Text("First Name") },
+            label = { Text("First Name*") },
+            isError = nameError,
+            supportingText = { if (nameError) Text("Required") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
@@ -401,7 +409,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.surname,
             onValueChange = viewModel::updateSurname,
-            label = { Text("Last Name") },
+            label = { Text("Last Name*") },
+            isError = surnameError,
+            supportingText = { if (surnameError) Text("Required") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
@@ -409,7 +419,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.parentMobile,
             onValueChange = viewModel::updateParentMobile,
-            label = { Text("Parent Mobile") },
+            label = { Text("Parent Mobile*") },
+            isError = phoneError,
+            supportingText = { if (phoneError) Text("Enter 10 digits") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
@@ -418,7 +430,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.parentEmail,
             onValueChange = viewModel::updateParentEmail,
-            label = { Text("Parent Email") },
+            label = { Text("Parent Email*") },
+            isError = emailError,
+            supportingText = { if (emailError) Text("Invalid email") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
@@ -452,10 +466,11 @@ private fun StudentEditForm(
             onValueChange = viewModel::updateRate,
             label = {
                 Text(
-                    if (uiState.rateType == RateTypes.HOURLY) "Hourly Rate (€)"
-                    else "Rate per Lesson (€)"
+                    if (uiState.rateType == RateTypes.HOURLY) "Hourly Rate (€)*" else "Rate per Lesson (€)*"
                 )
             },
+            isError = rateError,
+            supportingText = { if (rateError) Text("Required") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
@@ -476,7 +491,7 @@ private fun StudentEditForm(
                 value = uiState.className,
                 onValueChange = {},
                 readOnly = true,
-                label = { Text("Class") },
+                label = { Text("Class*") },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                 modifier = Modifier
                     .menuAnchor()

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
@@ -188,9 +188,9 @@ class StudentViewModel @Inject constructor(
         }
     }
 
-    private fun isPhoneValid(phone: String): Boolean = phone.matches(Regex("^\\d{10}$"))
+    fun isPhoneValid(phone: String): Boolean = phone.matches(Regex("^\\d{10}$"))
 
-    private fun isEmailValid(email: String): Boolean = Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    fun isEmailValid(email: String): Boolean = Patterns.EMAIL_ADDRESS.matcher(email).matches()
 
     fun isFormValid(): Boolean {
         val state = _uiState.value


### PR DESCRIPTION
## Summary
- use date/time pickers with Greek format
- show validation errors in Add/Edit Student form

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421daaa1a88330adc2f711d3b275a0