### PR TITLE
Improve lesson and student forms

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.compose.ui:ui-graphics"
+    implementation "androidx.compose.material:material-icons-extended"
     debugImplementation "androidx.compose.ui:ui-tooling"
     debugImplementation "androidx.compose.ui:ui-test-manifest"
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -1,11 +1,15 @@
 package gr.tsambala.tutorbilling.ui.lesson
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +32,7 @@ fun LessonScreen(
     viewModel: LessonViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     Scaffold(
         topBar = {
@@ -119,18 +124,52 @@ fun LessonScreen(
             // Date input
             OutlinedTextField(
                 value = uiState.date,
-                onValueChange = viewModel::updateDate,
-                label = { Text("Date (YYYY-MM-DD)") },
-                modifier = Modifier.fillMaxWidth(),
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Date") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        val current = try {
+                            LocalDate.parse(uiState.date, DateTimeFormatter.ofPattern("dd-MM-yyyy"))
+                        } catch (_: Exception) {
+                            LocalDate.now()
+                        }
+                        DatePickerDialog(
+                            context,
+                            { _, year, month, day ->
+                                val date = LocalDate.of(year, month + 1, day)
+                                viewModel.updateDate(date.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")))
+                            },
+                            current.year,
+                            current.monthValue - 1,
+                            current.dayOfMonth
+                        ).show()
+                    },
                 singleLine = true
             )
 
             // Time input
             OutlinedTextField(
                 value = uiState.startTime,
-                onValueChange = viewModel::updateStartTime,
-                label = { Text("Start Time (HH:MM)") },
-                modifier = Modifier.fillMaxWidth(),
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Start Time") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        val (h, m) = uiState.startTime.split(":").mapNotNull { it.toIntOrNull() }
+                            .let { if (it.size == 2) it[0] to it[1] else LocalTime.now().hour to LocalTime.now().minute }
+                        TimePickerDialog(
+                            context,
+                            { _, hour, minute ->
+                                viewModel.updateStartTime("%02d:%02d".format(hour, minute))
+                            },
+                            h,
+                            m,
+                            true
+                        ).show()
+                    },
                 singleLine = true
             )
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,6 +21,9 @@ class LessonViewModel @Inject constructor(
     private val lessonDao: LessonDao,
     private val studentDao: StudentDao
 ) : ViewModel() {
+
+    private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+    private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
     private val studentId: String? = savedStateHandle.get<String>("studentId")
     private val lessonId: String? = savedStateHandle.get<String>("lessonId")
@@ -35,8 +39,8 @@ class LessonViewModel @Inject constructor(
             // Set default values for new lesson
             _uiState.update {
                 it.copy(
-                    date = LocalDate.now().toString(),
-                    startTime = LocalTime.now().withSecond(0).withNano(0).toString()
+                    date = LocalDate.now().format(dateFormatter),
+                    startTime = LocalTime.now().withSecond(0).withNano(0).format(timeFormatter)
                 )
             }
         }
@@ -67,7 +71,7 @@ class LessonViewModel @Inject constructor(
                     lesson?.let { l ->
                         _uiState.update { state ->
                             state.copy(
-                                date = l.date,
+                                date = LocalDate.parse(l.date).format(dateFormatter),
                                 startTime = l.startTime,
                                 durationMinutes = l.durationMinutes.toString(),
                                 notes = l.notes ?: "",
@@ -99,12 +103,12 @@ class LessonViewModel @Inject constructor(
     }
 
     private fun isValidDate(value: String): Boolean = try {
-        LocalDate.parse(value)
+        LocalDate.parse(value, dateFormatter)
         true
     } catch (_: Exception) { false }
 
     private fun isValidTime(value: String): Boolean = try {
-        LocalTime.parse(value)
+        LocalTime.parse(value, timeFormatter)
         true
     } catch (_: Exception) { false }
 
@@ -128,7 +132,7 @@ class LessonViewModel @Inject constructor(
                 if (lessonId == "new") {
                     val lesson = Lesson(
                         studentId = sId,
-                        date = state.date,
+                        date = LocalDate.parse(state.date, dateFormatter).toString(),
                         startTime = state.startTime,
                         durationMinutes = duration,
                         notes = state.notes.ifBlank { null }
@@ -139,7 +143,7 @@ class LessonViewModel @Inject constructor(
                         val lesson = Lesson(
                             id = lId,
                             studentId = sId,
-                            date = state.date,
+                            date = LocalDate.parse(state.date, dateFormatter).toString(),
                             startTime = state.startTime,
                             durationMinutes = duration,
                             notes = state.notes.ifBlank { null }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -376,6 +376,7 @@ private fun LessonCard(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun StudentEditForm(
     uiState: StudentUiState,
@@ -384,6 +385,12 @@ private fun StudentEditForm(
     onCancel: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val nameError = uiState.name.isBlank()
+    val surnameError = uiState.surname.isBlank()
+    val phoneError = !viewModel.isPhoneValid(uiState.parentMobile)
+    val emailError = !viewModel.isEmailValid(uiState.parentEmail)
+    val rateError = uiState.rate.toDoubleOrNull() == null
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -393,7 +400,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.name,
             onValueChange = viewModel::updateName,
-            label = { Text("First Name") },
+            label = { Text("First Name*") },
+            isError = nameError,
+            supportingText = { if (nameError) Text("Required") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
@@ -401,7 +410,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.surname,
             onValueChange = viewModel::updateSurname,
-            label = { Text("Last Name") },
+            label = { Text("Last Name*") },
+            isError = surnameError,
+            supportingText = { if (surnameError) Text("Required") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
@@ -409,7 +420,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.parentMobile,
             onValueChange = viewModel::updateParentMobile,
-            label = { Text("Parent Mobile") },
+            label = { Text("Parent Mobile*") },
+            isError = phoneError,
+            supportingText = { if (phoneError) Text("Enter 10 digits") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
@@ -418,7 +431,9 @@ private fun StudentEditForm(
         OutlinedTextField(
             value = uiState.parentEmail,
             onValueChange = viewModel::updateParentEmail,
-            label = { Text("Parent Email") },
+            label = { Text("Parent Email*") },
+            isError = emailError,
+            supportingText = { if (emailError) Text("Invalid email") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
@@ -452,10 +467,11 @@ private fun StudentEditForm(
             onValueChange = viewModel::updateRate,
             label = {
                 Text(
-                    if (uiState.rateType == RateTypes.HOURLY) "Hourly Rate (€)"
-                    else "Rate per Lesson (€)"
+                    if (uiState.rateType == RateTypes.HOURLY) "Hourly Rate (€)*" else "Rate per Lesson (€)*"
                 )
             },
+            isError = rateError,
+            supportingText = { if (rateError) Text("Required") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
@@ -476,7 +492,7 @@ private fun StudentEditForm(
                 value = uiState.className,
                 onValueChange = {},
                 readOnly = true,
-                label = { Text("Class") },
+                label = { Text("Class*") },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                 modifier = Modifier
                     .menuAnchor()

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
@@ -188,9 +188,9 @@ class StudentViewModel @Inject constructor(
         }
     }
 
-    private fun isPhoneValid(phone: String): Boolean = phone.matches(Regex("^\\d{10}$"))
+    fun isPhoneValid(phone: String): Boolean = phone.matches(Regex("^\\d{10}$"))
 
-    private fun isEmailValid(email: String): Boolean = Patterns.EMAIL_ADDRESS.matcher(email).matches()
+    fun isEmailValid(email: String): Boolean = Patterns.EMAIL_ADDRESS.matcher(email).matches()
 
     fun isFormValid(): Boolean {
         val state = _uiState.value


### PR DESCRIPTION
## Summary
- use platform DatePickerDialog and TimePickerDialog with fully qualified names
- show validation errors in Add/Edit Student form
- fixed imports for dp and Sort icon
- fix time picker imports

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421daaa1a88330adc2f711d3b275a0