### PR TITLE
Add lessons list and redesign home layout

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -10,6 +10,7 @@ import gr.tsambala.tutorbilling.ui.students.StudentsScreen
 import gr.tsambala.tutorbilling.ui.classes.ClassesScreen
 import gr.tsambala.tutorbilling.ui.student.StudentScreen
 import gr.tsambala.tutorbilling.ui.lesson.LessonScreen
+import gr.tsambala.tutorbilling.ui.lessons.LessonsScreen
 
 @Composable
 fun TutorBillingApp(
@@ -22,7 +23,13 @@ fun TutorBillingApp(
         composable("home") {
             HomeMenuScreen(
                 onStudentsClick = { navController.navigate("students") },
-                onClassesClick = { navController.navigate("classes") }
+                onClassesClick = { navController.navigate("classes") },
+                onLessonsClick = { navController.navigate("lessons") },
+                onAddStudent = { navController.navigate("student/new") },
+                onAddLesson = {
+                    // Requires a student, direct user to select a student first
+                    navController.navigate("students")
+                }
             )
         }
 
@@ -37,6 +44,15 @@ fun TutorBillingApp(
 
         composable("classes") {
             ClassesScreen(onBack = { navController.popBackStack() })
+        }
+
+        composable("lessons") {
+            LessonsScreen(
+                onBack = { navController.popBackStack() },
+                onLessonClick = { studentId, lessonId ->
+                    navController.navigate("lesson/$studentId/$lessonId")
+                }
+            )
         }
 
         composable("student/{studentId}") { backStackEntry ->

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
@@ -1,8 +1,10 @@
 package gr.tsambala.tutorbilling.ui.home
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -11,36 +13,61 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun HomeMenuScreen(
     onStudentsClick: () -> Unit,
-    onClassesClick: () -> Unit
+    onClassesClick: () -> Unit,
+    onLessonsClick: () -> Unit,
+    onAddStudent: () -> Unit,
+    onAddLesson: () -> Unit
 ) {
+    var showFabMenu by remember { mutableStateOf(false) }
+
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Tutor Billing") },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            )
-        }
+        floatingActionButton = {
+            Box {
+                FloatingActionButton(onClick = { showFabMenu = !showFabMenu }) {
+                    Icon(Icons.Default.Add, contentDescription = "Add")
+                }
+                DropdownMenu(expanded = showFabMenu, onDismissRequest = { showFabMenu = false }) {
+                    DropdownMenuItem(text = { Text("Add Student") }, onClick = {
+                        showFabMenu = false
+                        onAddStudent()
+                    })
+                    DropdownMenuItem(text = { Text("Add Lesson") }, onClick = {
+                        showFabMenu = false
+                        onAddLesson()
+                    })
+                }
+            }
+        },
+        floatingActionButtonPosition = FabPosition.Center
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(32.dp),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(horizontal = 32.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top)
         ) {
+            Text(
+                text = "Tutor Billing",
+                style = MaterialTheme.typography.headlineLarge
+            )
+            Spacer(Modifier.height(16.dp))
             Button(
                 onClick = onStudentsClick,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
             ) { Text("Students") }
-            Spacer(modifier = Modifier.height(16.dp))
             Button(
                 onClick = onClassesClick,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
             ) { Text("Classes") }
+            Button(
+                onClick = onLessonsClick,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+            ) { Text("Lessons") }
         }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -1,0 +1,126 @@
+package gr.tsambala.tutorbilling.ui.lessons
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LessonsScreen(
+    onBack: () -> Unit,
+    onLessonClick: (Long, Long) -> Unit,
+    viewModel: LessonsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Lessons") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        if (uiState.lessons.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "No lessons recorded yet")
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                items(uiState.lessons, key = { it.lesson.id }) { item ->
+                    LessonItem(
+                        lessonWithStudent = item,
+                        onClick = { onLessonClick(item.student.id, item.lesson.id) }
+                    )
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LessonItem(
+    lessonWithStudent: LessonWithStudent,
+    onClick: () -> Unit
+) {
+    val lesson = lessonWithStudent.lesson
+    val student = lessonWithStudent.student
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = student.getFullName(),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = LocalDate.parse(lesson.date)
+                        .format(DateTimeFormatter.ofPattern("MMM d, yyyy")),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = "${lesson.startTime} • ${lesson.durationMinutes} min",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                lesson.notes?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            Text(
+                text = "€%.2f".format(lessonWithStudent.calculateFee()),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
@@ -1,0 +1,47 @@
+package gr.tsambala.tutorbilling.ui.lessons
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LessonsViewModel @Inject constructor(
+    private val lessonDao: LessonDao,
+    private val studentDao: StudentDao
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LessonsUiState())
+    val uiState: StateFlow<LessonsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                lessonDao.getAllLessons(),
+                studentDao.getAllActiveStudents()
+            ) { lessons, students ->
+                val map = students.associateBy { it.id }
+                lessons.mapNotNull { lesson ->
+                    map[lesson.studentId]?.let { student ->
+                        LessonWithStudent(lesson, student)
+                    }
+                }
+            }.collect { list ->
+                _uiState.update { it.copy(lessons = list) }
+            }
+        }
+    }
+}
+
+data class LessonsUiState(
+    val lessons: List<LessonWithStudent> = emptyList()
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="lesson_duration">Duration (minutes)</string>
     <string name="lesson_note">Note (optional)</string>
     <string name="no_lessons">No lessons recorded yet</string>
+    <string name="lessons">Lessons</string>
 
     <!-- Financial summary strings -->
     <string name="week_total">This Week</string>


### PR DESCRIPTION
## Summary
- refine home screen layout by removing the app bar
- display a placeholder logo text at the top of the home screen
- keep FAB in the center with add options

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f45a6ab0833096d8023cd84d063c