### PR TITLE
Implement new home and lesson features

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -27,8 +27,7 @@ fun TutorBillingApp(
                 onLessonsClick = { navController.navigate("lessons") },
                 onAddStudent = { navController.navigate("student/new") },
                 onAddLesson = {
-                    // Requires a student, direct user to select a student first
-                    navController.navigate("students")
+                    navController.navigate("lesson/null/new")
                 }
             )
         }
@@ -43,7 +42,10 @@ fun TutorBillingApp(
         }
 
         composable("classes") {
-            ClassesScreen(onBack = { navController.popBackStack() })
+            ClassesScreen(
+                onBack = { navController.popBackStack() },
+                onStudentClick = { id -> navController.navigate("student/$id") }
+            )
         }
 
         composable("lessons") {

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
@@ -3,11 +3,11 @@ package gr.tsambala.tutorbilling.ui.classes
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -17,11 +17,20 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 @Composable
 fun ClassesScreen(
     onBack: () -> Unit,
+    onStudentClick: (Long) -> Unit,
     viewModel: ClassesViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.hasUnassigned) {
+        if (uiState.hasUnassigned) {
+            snackbarHostState.showSnackbar("Some students are unassigned to a class")
+        }
+    }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text("Classes") },
@@ -54,8 +63,9 @@ fun ClassesScreen(
                 items(students) { student ->
                     Text(
                         text = "${student.name} ${student.surname}".trim(),
-
-                        modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp)
+                        modifier = Modifier
+                            .padding(horizontal = 32.dp, vertical = 8.dp)
+                            .clickable { onStudentClick(student.id) }
                     )
                 }
             }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesViewModel.kt
@@ -22,14 +22,17 @@ class ClassesViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             studentDao.getAllActiveStudents().map { students ->
-                students.groupBy { it.className }
-            }.collect { grouped ->
-                _uiState.value = ClassesUiState(grouped)
+                val grouped = students.groupBy { it.className }
+                val hasUnassigned = grouped["Unassigned"]?.isNotEmpty() == true
+                ClassesUiState(grouped, hasUnassigned)
+            }.collect { state ->
+                _uiState.value = state
             }
         }
     }
 }
 
 data class ClassesUiState(
-    val studentsByClass: Map<String, List<gr.tsambala.tutorbilling.data.model.Student>> = emptyMap()
+    val studentsByClass: Map<String, List<gr.tsambala.tutorbilling.data.model.Student>> = emptyMap(),
+    val hasUnassigned: Boolean = false
 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -16,9 +18,18 @@ fun HomeMenuScreen(
     onClassesClick: () -> Unit,
     onLessonsClick: () -> Unit,
     onAddStudent: () -> Unit,
-    onAddLesson: () -> Unit
+    onAddLesson: () -> Unit,
+    viewModel: HomeMenuViewModel = hiltViewModel()
 ) {
     var showFabMenu by remember { mutableStateOf(false) }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val studentsColor = if (uiState.studentCount > 0)
+        MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primaryContainer
+    val classesColor = if (uiState.classCount > 0)
+        MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.secondaryContainer
+    val lessonsColor = if (uiState.lessonCount > 0)
+        MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.tertiaryContainer
 
     Scaffold(
         floatingActionButton = {
@@ -46,7 +57,7 @@ fun HomeMenuScreen(
                 .padding(padding)
                 .padding(horizontal = 32.dp, vertical = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top)
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
             Text(
                 text = "Tutor Billing",
@@ -56,17 +67,17 @@ fun HomeMenuScreen(
             Button(
                 onClick = onStudentsClick,
                 modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+                colors = ButtonDefaults.buttonColors(containerColor = studentsColor)
             ) { Text("Students") }
             Button(
                 onClick = onClassesClick,
                 modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                colors = ButtonDefaults.buttonColors(containerColor = classesColor)
             ) { Text("Classes") }
             Button(
                 onClick = onLessonsClick,
                 modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+                colors = ButtonDefaults.buttonColors(containerColor = lessonsColor)
             ) { Text("Lessons") }
         }
     }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
@@ -1,0 +1,50 @@
+package gr.tsambala.tutorbilling.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeMenuViewModel @Inject constructor(
+    private val studentDao: StudentDao,
+    private val lessonDao: LessonDao
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeMenuUiState())
+    val uiState: StateFlow<HomeMenuUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                studentDao.getAllActiveStudents(),
+                lessonDao.getAllLessons()
+            ) { students, lessons ->
+                val classCount = students.map { it.className.lowercase() }
+                    .filter { it != "unassigned" }
+                    .distinct()
+                    .size
+                HomeMenuUiState(
+                    studentCount = students.size,
+                    classCount = classCount,
+                    lessonCount = lessons.size
+                )
+            }.collect { state ->
+                _uiState.value = state
+            }
+        }
+    }
+}
+
+data class HomeMenuUiState(
+    val studentCount: Int = 0,
+    val classCount: Int = 0,
+    val lessonCount: Int = 0
+)

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import androidx.compose.ui.platform.LocalContext
@@ -95,7 +97,7 @@ fun LessonScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            // Student info (read-only)
+            // Student info or picker
             if (uiState.studentName.isNotEmpty()) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -119,6 +121,39 @@ fun LessonScreen(
                             },
                             style = MaterialTheme.typography.bodyMedium
                         )
+                    }
+                }
+            } else if (uiState.availableStudents.isNotEmpty()) {
+                var expanded by remember { mutableStateOf(false) }
+                ExposedDropdownMenuBox(
+                    expanded = expanded,
+                    onExpandedChange = { expanded = !expanded }
+                ) {
+                    OutlinedTextField(
+                        value = uiState.selectedStudentId?.let { id ->
+                            uiState.availableStudents.firstOrNull { it.id == id }?.getFullName()
+                        } ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Student*") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                        modifier = Modifier
+                            .menuAnchor()
+                            .fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        uiState.availableStudents.forEach { student ->
+                            DropdownMenuItem(
+                                text = { Text(student.getFullName()) },
+                                onClick = {
+                                    viewModel.updateSelectedStudent(student.id)
+                                    expanded = false
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -176,15 +211,16 @@ fun LessonScreen(
                 singleLine = true
             )
 
-            // Duration input
-            OutlinedTextField(
-                value = uiState.durationMinutes,
-                onValueChange = viewModel::updateDuration,
-                label = { Text("Duration (minutes)") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true
-            )
+            if (uiState.studentRateType == RateTypes.HOURLY) {
+                OutlinedTextField(
+                    value = uiState.durationMinutes,
+                    onValueChange = viewModel::updateDuration,
+                    label = { Text("Duration (minutes)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
 
             // Fee calculation
             Card(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -514,6 +514,18 @@ private fun StudentEditForm(
             }
         }
 
+        if (uiState.className == "Custom") {
+            OutlinedTextField(
+                value = uiState.customClass,
+                onValueChange = viewModel::updateCustomClass,
+                label = { Text("Class Description*") },
+                isError = uiState.classError,
+                supportingText = { if (uiState.classError) Text("Class already exists") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+        }
+
         Spacer(modifier = Modifier.weight(1f))
 
         Row(


### PR DESCRIPTION
## Summary
- center home menu buttons and change colours based on existing data
- add HomeMenuViewModel to supply counts
- navigate directly to add-lesson screen
- show warnings on classes screen and allow tapping students
- support custom classes when editing students
- allow adding lessons without selecting a student first and hide duration for per-lesson rates

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448a6954e083308ba4e1be42a04ba3