### PR TITLE
Implement basic settings and search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation "androidx.room:room-ktx:2.6.1"
     kapt "androidx.room:room-compiler:2.6.1"
 
+    // DataStore for app settings
+    implementation "androidx.datastore:datastore-preferences:1.0.0"
+
     // Hilt - Updated to compatible version
     implementation "com.google.dagger:hilt-android:2.48"
     kapt "com.google.dagger:hilt-android-compiler:2.48"

--- a/app/src/main/java/gr/tsambala/tutorbilling/MainActivity.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/MainActivity.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.ui.settings.SettingsViewModel
+import gr.tsambala.tutorbilling.ui.theme.TutorBillingTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -14,7 +18,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MaterialTheme {
+            val viewModel: SettingsViewModel = hiltViewModel()
+            val settings = viewModel.settings.collectAsStateWithLifecycle().value
+            TutorBillingTheme(darkTheme = settings.darkTheme) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -28,7 +28,9 @@ fun TutorBillingApp(
                 onAddStudent = { navController.navigate("student/new") },
                 onAddLesson = {
                     navController.navigate("lesson/null/new")
-                }
+                },
+                onSettings = { navController.navigate("settings") },
+                onSearch = { navController.navigate("search") }
             )
         }
 
@@ -82,6 +84,18 @@ fun TutorBillingApp(
                 onNavigateBack = {
                     navController.popBackStack()
                 }
+            )
+        }
+
+        composable("settings") {
+            gr.tsambala.tutorbilling.ui.settings.SettingsScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable("search") {
+            gr.tsambala.tutorbilling.ui.search.GlobalSearchScreen(
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/settings/SettingsRepository.kt
@@ -1,0 +1,52 @@
+package gr.tsambala.tutorbilling.data.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.settingsDataStore by preferencesDataStore(name = "settings")
+
+data class AppSettings(
+    val currencySymbol: String = "€",
+    val roundingDecimals: Int = 2,
+    val darkTheme: Boolean = false
+)
+
+@Singleton
+class SettingsRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private object Keys {
+        val CURRENCY = stringPreferencesKey("currency_symbol")
+        val ROUNDING = intPreferencesKey("rounding_decimals")
+        val DARK_THEME = booleanPreferencesKey("dark_theme")
+    }
+
+    val settings: Flow<AppSettings> = context.settingsDataStore.data.map { prefs ->
+        AppSettings(
+            currencySymbol = prefs[Keys.CURRENCY] ?: "€",
+            roundingDecimals = prefs[Keys.ROUNDING] ?: 2,
+            darkTheme = prefs[Keys.DARK_THEME] ?: false
+        )
+    }
+
+    suspend fun setCurrencySymbol(symbol: String) {
+        context.settingsDataStore.edit { it[Keys.CURRENCY] = symbol }
+    }
+
+    suspend fun setRounding(decimals: Int) {
+        context.settingsDataStore.edit { it[Keys.ROUNDING] = decimals }
+    }
+
+    suspend fun setDarkTheme(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.DARK_THEME] = enabled }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
@@ -3,6 +3,8 @@ package gr.tsambala.tutorbilling.ui.home
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -10,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.ui.settings.SettingsViewModel
+import gr.tsambala.tutorbilling.utils.formatAsCurrency
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -19,10 +23,14 @@ fun HomeMenuScreen(
     onLessonsClick: () -> Unit,
     onAddStudent: () -> Unit,
     onAddLesson: () -> Unit,
-    viewModel: HomeMenuViewModel = hiltViewModel()
+    onSettings: () -> Unit,
+    onSearch: () -> Unit,
+    viewModel: HomeMenuViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     var showFabMenu by remember { mutableStateOf(false) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
 
     val studentsColor = if (uiState.studentCount > 0)
         MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primaryContainer
@@ -32,6 +40,19 @@ fun HomeMenuScreen(
         MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.tertiaryContainer
 
     Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Tutor Billing") },
+                actions = {
+                    IconButton(onClick = onSearch) {
+                        Icon(Icons.Default.Search, contentDescription = "Search")
+                    }
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    }
+                }
+            )
+        },
         floatingActionButton = {
             Box {
                 FloatingActionButton(onClick = { showFabMenu = !showFabMenu }) {
@@ -59,11 +80,24 @@ fun HomeMenuScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
-            Text(
-                text = "Tutor Billing",
-                style = MaterialTheme.typography.headlineLarge
-            )
-            Spacer(Modifier.height(16.dp))
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
+                Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("This week", style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        uiState.weekRevenue.formatAsCurrency(settings.currencySymbol, settings.roundingDecimals),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
+                Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("This month", style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        uiState.monthRevenue.formatAsCurrency(settings.currencySymbol, settings.roundingDecimals),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
             Button(
                 onClick = onStudentsClick,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/search/GlobalSearchScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/search/GlobalSearchScreen.kt
@@ -1,0 +1,53 @@
+package gr.tsambala.tutorbilling.ui.search
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun GlobalSearchScreen(
+    onBack: () -> Unit,
+    viewModel: SearchViewModel = hiltViewModel()
+) {
+    val results by viewModel.results.collectAsStateWithLifecycle()
+    val query by viewModel.searchQuery.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Back") }
+                },
+                title = {
+                    TextField(
+                        value = query,
+                        onValueChange = viewModel::updateQuery,
+                        placeholder = { Text("Search students") },
+                        singleLine = true
+                    )
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+        ) {
+            items(results, key = { it.id }) { student ->
+                Text("${student.name} ${student.surname}", style = MaterialTheme.typography.bodyLarge)
+                Divider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/search/SearchViewModel.kt
@@ -1,0 +1,34 @@
+package gr.tsambala.tutorbilling.ui.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val studentDao: StudentDao
+) : ViewModel() {
+    private val query = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = query.asStateFlow()
+    private val _results = MutableStateFlow(emptyList<gr.tsambala.tutorbilling.data.model.Student>())
+    val results: StateFlow<List<gr.tsambala.tutorbilling.data.model.Student>> = _results.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            query
+                .debounce(300)
+                .flatMapLatest { studentDao.searchStudentsByName(it) }
+                .collect { _results.value = it }
+        }
+    }
+
+    fun updateQuery(q: String) { query.value = q }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
@@ -1,0 +1,65 @@
+package gr.tsambala.tutorbilling.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit,
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val settings by viewModel.settings.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                title = { Text("Settings") }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = settings.currencySymbol,
+                onValueChange = viewModel::updateCurrencySymbol,
+                label = { Text("Currency symbol") }
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Decimal places: ${settings.roundingDecimals}")
+                Slider(
+                    value = settings.roundingDecimals.toFloat(),
+                    onValueChange = { viewModel.updateRounding(it.toInt()) },
+                    valueRange = 0f..2f,
+                    steps = 1,
+                    modifier = Modifier.weight(1f).padding(start = 8.dp)
+                )
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Dark theme")
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = settings.darkTheme,
+                    onCheckedChange = viewModel::updateDarkTheme
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,39 @@
+package gr.tsambala.tutorbilling.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.settings.AppSettings
+import gr.tsambala.tutorbilling.data.settings.SettingsRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val repository: SettingsRepository
+) : ViewModel() {
+    private val _settings = MutableStateFlow(AppSettings())
+    val settings: StateFlow<AppSettings> = _settings.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.settings.collectLatest { _settings.value = it }
+        }
+    }
+
+    fun updateCurrencySymbol(symbol: String) {
+        viewModelScope.launch { repository.setCurrencySymbol(symbol) }
+    }
+
+    fun updateRounding(decimals: Int) {
+        viewModelScope.launch { repository.setRounding(decimals) }
+    }
+
+    fun updateDarkTheme(enabled: Boolean) {
+        viewModelScope.launch { repository.setDarkTheme(enabled) }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -27,15 +27,16 @@ import java.util.Locale
  * - 100.0 -> "€100.00"
  * - 0.0 -> "€0.00"
  */
-fun Double.formatAsCurrency(): String {
-    return "€%.2f".format(this)
+fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
+    return "$symbol%.${'$'}decimalsf".format(this)
 }
 
 /**
  * Formats a nullable Double as currency, returning a default for null values.
  */
-fun Double?.formatAsCurrencyOrDefault(default: String = "€0.00"): String {
-    return this?.formatAsCurrency() ?: default
+fun Double?.formatAsCurrencyOrDefault(symbol: String = "€", decimals: Int = 2): String {
+    val default = "$symbol%.${'$'}decimalsf".format(0.0)
+    return this?.formatAsCurrency(symbol, decimals) ?: default
 }
 
 // ===== Date Formatting =====


### PR DESCRIPTION
## Summary
- add a SettingsRepository backed by DataStore
- create Settings screen and view model
- integrate dark theme preference in MainActivity
- compute revenue totals in `HomeMenuViewModel`
- show weekly/monthly revenue tiles in home menu
- allow navigation to Settings and new global search screen
- add simple student search implementation
- optimize search query handling

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68448e52ba208330b9e6a154de76d807