### PR TITLE
Add Codex Android exec config

### DIFF
--- a/.codex/exec.yaml
+++ b/.codex/exec.yaml
@@ -1,0 +1,1 @@
+image: android


### PR DESCRIPTION
## Summary
- configure codex to use the `android` image for builds

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844933c850c833084b7b2899e64da56