### PR TITLE
Fix compile issues and bump version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "gr.tsambala.tutorbilling"
         minSdk 26
         targetSdk 34
-        versionCode 1
-        versionName "0.1"
+        versionCode 2
+        versionName "0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.model.calculateFee
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,


### PR DESCRIPTION
## Summary
- add missing calculateFee import
- allow experimental Material3 API and import Alignment in settings screen
- bump app version to 0.2

## Testing
- `./gradlew :app:compileDebugKotlin --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad1b55b88330bc3237508bd580f4