### PR TITLE
Simplify StudentsViewModel flow handling

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsViewModel.kt
@@ -23,21 +23,22 @@ class StudentsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(StudentsUiState())
     val uiState: StateFlow<StudentsUiState> = _uiState.asStateFlow()
 
-    private val searchQuery = MutableStateFlow("")
-    private val sortAscending = MutableStateFlow(true)
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _sortAscending = MutableStateFlow(true)
+    val sortAscending: StateFlow<Boolean> = _sortAscending.asStateFlow()
 
     init {
         loadStudentsWithEarnings()
     }
 
     fun updateSearchQuery(query: String) {
-        searchQuery.value = query
-        loadStudentsWithEarnings()
+        _searchQuery.value = query
     }
 
     fun toggleSortOrder() {
-        sortAscending.value = !sortAscending.value
-        loadStudentsWithEarnings()
+        _sortAscending.value = !_sortAscending.value
     }
 
     private fun loadStudentsWithEarnings() {
@@ -88,7 +89,7 @@ class StudentsViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         students = studentsWithEarnings,
-                        searchQuery = searchQuery.value
+                        searchQuery = _searchQuery.value
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- expose `searchQuery` and `sortAscending` as `StateFlow`s
- recompute the student list by combining flows once in init
- remove repeated coroutines when search or sort order changes

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d3f2df1083309b0d992ddbf147d5