### PR TITLE
Add README and improve CI build steps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Build
+      - name: Build and Lint
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test
+          arguments: lint build

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+**/build/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# TutorBillingApp
+
+An Android application for managing tutor billing.
+
+## Prerequisites
+
+- **JDK 17**
+- **Android SDK** with API level 34
+- **Gradle** (wrapper provided)
+
+## Building
+
+To build the project from the command line run:
+
+```bash
+./gradlew lint build
+```
+
+This will run Android lint checks and compile the project.
+You can also open the project in **Android Studio** for development.
+


### PR DESCRIPTION
## Summary
- add initial README with build instructions
- ignore build directories
- run lint and build in GitHub Actions

## Testing
- `./gradlew lint build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684601d8de048330afd8ec4436ab0a16