### PR TITLE
Fix currency formatting and migration

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -19,6 +19,18 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
 
 val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE students ADD COLUMN isActive INTEGER NOT NULL DEFAULT 1")
+        // Add the isActive column only if it doesn't already exist
+        val cursor = database.query("PRAGMA table_info(students)")
+        var hasColumn = false
+        while (cursor.moveToNext()) {
+            if (cursor.getString(cursor.getColumnIndexOrThrow("name")) == "isActive") {
+                hasColumn = true
+                break
+            }
+        }
+        cursor.close()
+        if (!hasColumn) {
+            database.execSQL("ALTER TABLE students ADD COLUMN isActive INTEGER NOT NULL DEFAULT 1")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle IllegalFormatPrecisionException in currency formatter
- clamp decimal places used in currency formatting
- add safety check before adding `isActive` column during migration

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460441fb2c833091a36beedb378cc8