### PR TITLE
Fix currency precision and migration check

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -19,6 +19,20 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
 
 val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE students ADD COLUMN isActive INTEGER NOT NULL DEFAULT 1")
+        // Add the isActive column only if it doesn't already exist
+        var hasColumn = false
+        database.query("PRAGMA table_info(students)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                if (nameIndex != -1 && cursor.getString(nameIndex) == "isActive") {
+                    hasColumn = true
+                    break
+                }
+            }
+        }
+
+        if (!hasColumn) {
+            database.execSQL("ALTER TABLE students ADD COLUMN isActive INTEGER NOT NULL DEFAULT 1")
+        }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
+import java.util.IllegalFormatPrecisionException
 
 /**
  * AppUtils contains utility functions and extension methods used throughout the app.
@@ -28,15 +29,23 @@ import java.util.Locale
  * - 0.0 -> "€0.00"
  */
 fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
-    return "$symbol${"%.${decimals}f".format(this)}"
+    // Clamp decimals to 0..2. Any invalid value defaults to 2
+    val safeDecimals = decimals.takeIf { it in 0..2 } ?: 2
+    return try {
+        "$symbol${"%.${safeDecimals}f".format(this)}"
+    } catch (e: IllegalFormatPrecisionException) {
+        // Fallback to two decimal places if formatting fails
+        "$symbol${"%.2f".format(this)}"
+    }
 }
 
 /**
  * Formats a nullable Double as currency, returning a default for null values.
  */
 fun Double?.formatAsCurrencyOrDefault(symbol: String = "€", decimals: Int = 2): String {
-    val default = "$symbol${"%.${decimals}f".format(0.0)}"
-    return this?.formatAsCurrency(symbol, decimals) ?: default
+    val safeDecimals = decimals.takeIf { it in 0..2 } ?: 2
+    val default = "$symbol${"%.${safeDecimals}f".format(0.0)}"
+    return this?.formatAsCurrency(symbol, safeDecimals) ?: default
 }
 
 // ===== Date Formatting =====


### PR DESCRIPTION
## Summary
- cap decimal precision at 2 in `formatAsCurrency`
- guard schema migration using PRAGMA check

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460441fb2c833091a36beedb378cc8