### PR TITLE
Implement revenue screen and UI updates

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -29,8 +29,8 @@ fun TutorBillingApp(
                 onAddLesson = {
                     navController.navigate("lesson/null/new")
                 },
-                onSettings = { navController.navigate("settings") },
-                onSearch = { navController.navigate("search") }
+                onRevenue = { navController.navigate("revenue") },
+                onSettings = { navController.navigate("settings") }
             )
         }
 
@@ -39,7 +39,8 @@ fun TutorBillingApp(
                 onNavigateToStudent = { studentId ->
                     navController.navigate("student/$studentId")
                 },
-                onAddStudent = { navController.navigate("student/new") }
+                onAddStudent = { navController.navigate("student/new") },
+                onBack = { navController.popBackStack() }
             )
         }
 
@@ -89,6 +90,12 @@ fun TutorBillingApp(
 
         composable("settings") {
             gr.tsambala.tutorbilling.ui.settings.SettingsScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable("revenue") {
+            gr.tsambala.tutorbilling.ui.revenue.RevenueScreen(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
@@ -3,8 +3,8 @@ package gr.tsambala.tutorbilling.ui.home
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -12,8 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import gr.tsambala.tutorbilling.ui.settings.SettingsViewModel
-import gr.tsambala.tutorbilling.utils.formatAsCurrency
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -23,14 +22,12 @@ fun HomeMenuScreen(
     onLessonsClick: () -> Unit,
     onAddStudent: () -> Unit,
     onAddLesson: () -> Unit,
+    onRevenue: () -> Unit,
     onSettings: () -> Unit,
-    onSearch: () -> Unit,
-    viewModel: HomeMenuViewModel = hiltViewModel(),
-    settingsViewModel: SettingsViewModel = hiltViewModel()
+    viewModel: HomeMenuViewModel = hiltViewModel()
 ) {
     var showFabMenu by remember { mutableStateOf(false) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
 
     val studentsColor = if (uiState.studentCount > 0)
         MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primaryContainer
@@ -40,24 +37,30 @@ fun HomeMenuScreen(
         MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.tertiaryContainer
 
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Tutor Billing") },
-                actions = {
-                    IconButton(onClick = onSearch) {
-                        Icon(Icons.Default.Search, contentDescription = "Search")
-                    }
-                    IconButton(onClick = onSettings) {
-                        Icon(Icons.Default.Settings, contentDescription = "Settings")
-                    }
-                }
-            )
+        bottomBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                FloatingActionButton(
+                    onClick = onRevenue,
+                    containerColor = MaterialTheme.colorScheme.secondary
+                ) { Icon(Icons.Default.BarChart, contentDescription = "Revenue") }
+                FloatingActionButton(
+                    onClick = { showFabMenu = !showFabMenu },
+                    containerColor = MaterialTheme.colorScheme.primary
+                ) { Icon(Icons.Default.Add, contentDescription = "Add") }
+                FloatingActionButton(
+                    onClick = onSettings,
+                    containerColor = MaterialTheme.colorScheme.tertiary
+                ) { Icon(Icons.Default.Settings, contentDescription = "Settings") }
+            }
         },
         floatingActionButton = {
             Box {
-                FloatingActionButton(onClick = { showFabMenu = !showFabMenu }) {
-                    Icon(Icons.Default.Add, contentDescription = "Add")
-                }
+                FloatingActionButton(onClick = { showFabMenu = !showFabMenu }) {}
                 DropdownMenu(expanded = showFabMenu, onDismissRequest = { showFabMenu = false }) {
                     DropdownMenuItem(text = { Text("Add Student") }, onClick = {
                         showFabMenu = false
@@ -80,24 +83,8 @@ fun HomeMenuScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
         ) {
-            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
-                Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("This week", style = MaterialTheme.typography.labelSmall)
-                    Text(
-                        uiState.weekRevenue.formatAsCurrency(settings.currencySymbol, settings.roundingDecimals),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-            }
-            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)) {
-                Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text("This month", style = MaterialTheme.typography.labelSmall)
-                    Text(
-                        uiState.monthRevenue.formatAsCurrency(settings.currencySymbol, settings.roundingDecimals),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                }
-            }
+            Spacer(Modifier.height(32.dp))
+            Text("Tutor Billing", style = MaterialTheme.typography.headlineMedium)
             Button(
                 onClick = onStudentsClick,
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -58,15 +58,6 @@ fun LessonScreen(
                             Icon(Icons.Default.Delete, contentDescription = "Delete")
                         }
                     }
-                    TextButton(
-                        onClick = {
-                            viewModel.saveLesson()
-                            onNavigateBack()
-                        },
-                        enabled = viewModel.isFormValid()
-                    ) {
-                        Text("Save")
-                    }
 
                     if (showDelete) {
                         AlertDialog(
@@ -98,7 +89,7 @@ fun LessonScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             // Student info or picker
-            if (uiState.studentName.isNotEmpty()) {
+            if (uiState.availableStudents.isEmpty()) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(
@@ -123,7 +114,7 @@ fun LessonScreen(
                         )
                     }
                 }
-            } else if (uiState.availableStudents.isNotEmpty()) {
+            } else {
                 var expanded by remember { mutableStateOf(false) }
                 ExposedDropdownMenuBox(
                     expanded = expanded,
@@ -159,7 +150,6 @@ fun LessonScreen(
             }
 
             // Date input
-            val context = LocalContext.current
             OutlinedTextField(
                 value = uiState.date,
                 onValueChange = {},
@@ -257,6 +247,26 @@ fun LessonScreen(
                 minLines = 3,
                 maxLines = 5
             )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedButton(
+                    onClick = onNavigateBack,
+                    modifier = Modifier.weight(1f)
+                ) { Text("Cancel") }
+                Button(
+                    onClick = {
+                        viewModel.saveLesson()
+                        onNavigateBack()
+                    },
+                    modifier = Modifier.weight(1f),
+                    enabled = viewModel.isFormValid()
+                ) { Text("Save") }
+            }
         }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
@@ -1,0 +1,99 @@
+package gr.tsambala.tutorbilling.ui.revenue
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.ui.settings.SettingsViewModel
+import gr.tsambala.tutorbilling.utils.formatAsCurrency
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RevenueScreen(
+    onBack: () -> Unit,
+    viewModel: RevenueViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Students") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                MetricTile(
+                    label = "Daily",
+                    value = uiState.dailyRevenue.formatAsCurrency(
+                        settings.currencySymbol,
+                        settings.roundingDecimals
+                    ),
+                    modifier = Modifier.weight(1f),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+                MetricTile(
+                    label = "Weekly",
+                    value = uiState.weeklyRevenue.formatAsCurrency(
+                        settings.currencySymbol,
+                        settings.roundingDecimals
+                    ),
+                    modifier = Modifier.weight(1f),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                )
+                MetricTile(
+                    label = "Monthly",
+                    value = uiState.monthlyRevenue.formatAsCurrency(
+                        settings.currencySymbol,
+                        settings.roundingDecimals
+                    ),
+                    modifier = Modifier.weight(1f),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricTile(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    containerColor: androidx.compose.ui.graphics.Color
+) {
+    Card(modifier = modifier, colors = CardDefaults.cardColors(containerColor = containerColor)) {
+        Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(label, style = MaterialTheme.typography.labelSmall)
+            Text(value, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModel.kt
@@ -1,0 +1,80 @@
+package gr.tsambala.tutorbilling.ui.revenue
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.model.calculateFee
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+
+@HiltViewModel
+class RevenueViewModel @Inject constructor(
+    private val studentDao: StudentDao,
+    private val lessonDao: LessonDao
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RevenueUiState())
+    val uiState: StateFlow<RevenueUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                studentDao.getAllActiveStudents(),
+                lessonDao.getAllLessons()
+            ) { students, lessons ->
+                val studentMap = students.associateBy { it.id }
+
+                val today = LocalDate.now()
+                val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                val weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+                val monthStart = today.withDayOfMonth(1)
+                val monthEnd = today.withDayOfMonth(today.lengthOfMonth())
+
+                val dayTotal = lessons.filter { it.date == today.toString() }
+                    .sumOf { lesson ->
+                        val student = studentMap[lesson.studentId] ?: return@sumOf 0.0
+                        lesson.calculateFee(student)
+                    }
+
+                val weekTotal = lessons.filter { lesson ->
+                    val date = LocalDate.parse(lesson.date)
+                    !date.isBefore(weekStart) && !date.isAfter(weekEnd)
+                }.sumOf { lesson ->
+                    val student = studentMap[lesson.studentId] ?: return@sumOf 0.0
+                    lesson.calculateFee(student)
+                }
+
+                val monthTotal = lessons.filter { lesson ->
+                    val date = LocalDate.parse(lesson.date)
+                    !date.isBefore(monthStart) && !date.isAfter(monthEnd)
+                }.sumOf { lesson ->
+                    val student = studentMap[lesson.studentId] ?: return@sumOf 0.0
+                    lesson.calculateFee(student)
+                }
+
+                RevenueUiState(
+                    dailyRevenue = dayTotal,
+                    weeklyRevenue = weekTotal,
+                    monthlyRevenue = monthTotal
+                )
+            }.collect { state ->
+                _uiState.value = state
+            }
+        }
+    }
+}
+
+data class RevenueUiState(
+    val dailyRevenue: Double = 0.0,
+    val weeklyRevenue: Double = 0.0,
+    val monthlyRevenue: Double = 0.0
+)

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -22,6 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 fun StudentsScreen(
     onNavigateToStudent: (Long) -> Unit,
     onAddStudent: () -> Unit,
+    onBack: () -> Unit,
     viewModel: StudentsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -29,7 +31,12 @@ fun StudentsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Tutor Billing") },
+                title = { Text("Students") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer


### PR DESCRIPTION
## Summary
- redesign Home screen layout with bottom bar and placeholder logo
- move Settings button to bottom bar and add revenue shortcut
- update Students screen with back arrow title bar
- add Revenue screen and ViewModel for metrics
- fix Add Lesson screen layout and student selection logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684694e6e48c8330a45f1d97b9392947