### PR TITLE
Switch from kapt to ksp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
     id 'com.google.dagger.hilt.android'
     id 'org.jetbrains.kotlin.plugin.compose'
 }
@@ -78,14 +78,14 @@ dependencies {
     // Room
     implementation "androidx.room:room-runtime:2.7.1"
     implementation "androidx.room:room-ktx:2.7.1"
-    kapt "androidx.room:room-compiler:2.7.1"
+    ksp "androidx.room:room-compiler:2.7.1"
 
     // DataStore for app settings
     implementation "androidx.datastore:datastore-preferences:1.1.7"
 
     // Hilt - Updated to compatible version
     implementation "com.google.dagger:hilt-android:2.54"
-    kapt "com.google.dagger:hilt-android-compiler:2.54"
+    ksp "com.google.dagger:hilt-compiler:2.54"
 
     // Testing
     testImplementation "junit:junit:4.13.2"
@@ -93,7 +93,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:3.6.1"
 }
 
-// Allow references to generated code
-kapt {
-    correctErrorTypes true
+// Room schema location for ksp
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.10.0'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10'
+        classpath 'com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.1.10-1.0.30'
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.54'
         classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.1.10'
     }


### PR DESCRIPTION
## Summary
- switch annotation processing from kapt to ksp
- configure Room schema location via ksp

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684697a96d148330901e4cec688094b8