### PR TITLE
Add invoice generation feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,16 @@
             </intent-filter>
         </activity>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -96,6 +96,13 @@ fun TutorBillingApp(
 
         composable("revenue") {
             gr.tsambala.tutorbilling.ui.revenue.RevenueScreen(
+                onBack = { navController.popBackStack() },
+                onInvoice = { navController.navigate("invoice") }
+            )
+        }
+
+        composable("invoice") {
+            gr.tsambala.tutorbilling.ui.invoice.InvoiceScreen(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
@@ -29,4 +29,10 @@ interface LessonDao {
 
     @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate ORDER BY date DESC, startTime DESC")
     fun getLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>>
+
+    @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate AND isPaid = 0 ORDER BY date ASC")
+    fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>>
+
+    @Query("UPDATE lessons SET isPaid = :paid WHERE id IN (:ids)")
+    suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean)
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -37,3 +37,9 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
         }
     }
 }
+
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE lessons ADD COLUMN isPaid INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -10,7 +10,7 @@ import gr.tsambala.tutorbilling.data.model.Lesson
 
 @Database(
     entities = [Student::class, Lesson::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(DateTimeConverters::class)

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
@@ -24,5 +24,6 @@ data class Lesson(
     val date: String,
     val startTime: String,
     val durationMinutes: Int,
-    val notes: String? = null
+    val notes: String? = null,
+    val isPaid: Boolean = false
 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
@@ -13,6 +13,7 @@ import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
 import gr.tsambala.tutorbilling.data.database.MIGRATION_1_2
 import gr.tsambala.tutorbilling.data.database.MIGRATION_2_3
 import gr.tsambala.tutorbilling.data.database.MIGRATION_3_4
+import gr.tsambala.tutorbilling.data.database.MIGRATION_4_5
 import javax.inject.Singleton
 
 @Module
@@ -29,7 +30,7 @@ object DatabaseModule {
             TutorBillingDatabase::class.java,
             "tutor_billing_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
             .build()
     }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -1,0 +1,154 @@
+package gr.tsambala.tutorbilling.ui.invoice
+
+import android.app.DatePickerDialog
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.core.content.FileProvider
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.io.FileOutputStream
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InvoiceScreen(
+    onBack: () -> Unit,
+    viewModel: InvoiceViewModel = hiltViewModel()
+) {
+    val startDate by viewModel.startDate.collectAsStateWithLifecycle()
+    val endDate by viewModel.endDate.collectAsStateWithLifecycle()
+    val lessons by viewModel.lessons.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Invoice") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedButton(onClick = onBack, modifier = Modifier.weight(1f)) { Text("Cancel") }
+                Button(
+                    onClick = {
+                        val uri = createInvoicePdf(context.cacheDir, lessons)
+                        val share = Intent(Intent.ACTION_SEND).apply {
+                            type = "application/pdf"
+                            putExtra(Intent.EXTRA_STREAM, FileProvider.getUriForFile(context, "${context.packageName}.provider", File(uri.path!!)))
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        context.startActivity(Intent.createChooser(share, null))
+                    },
+                    modifier = Modifier.weight(1f),
+                    enabled = lessons.isNotEmpty()
+                ) { Text("Share PDF") }
+            }
+        }
+    ) { padding ->
+        Column(Modifier.padding(padding).padding(16.dp)) {
+            DateField("Start", startDate) { date -> viewModel.updateStartDate(date) }
+            DateField("End", endDate) { date -> viewModel.updateEndDate(date) }
+
+            if (lessons.isEmpty()) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No unpaid lessons")
+                }
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(lessons) { item ->
+                        LessonRow(item)
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LessonRow(item: LessonWithStudent) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column {
+            Text(item.student.getFullName(), style = MaterialTheme.typography.bodyMedium)
+            Text(LocalDate.parse(item.lesson.date).format(DateTimeFormatter.ofPattern("dd MMM")))
+        }
+        Text("€%.2f".format(item.calculateFee()))
+    }
+}
+
+@Composable
+private fun DateField(label: String, date: LocalDate, onDate: (LocalDate) -> Unit) {
+    val context = LocalContext.current
+    OutlinedTextField(
+        value = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                DatePickerDialog(
+                    context,
+                    { _, y, m, d -> onDate(LocalDate.of(y, m + 1, d)) },
+                    date.year,
+                    date.monthValue - 1,
+                    date.dayOfMonth
+                ).show()
+            }
+    )
+}
+
+fun createInvoicePdf(cacheDir: File, lessons: List<LessonWithStudent>): Uri {
+    val pdf = android.graphics.pdf.PdfDocument()
+    val pageInfo = android.graphics.pdf.PdfDocument.PageInfo.Builder(595, 842, 1).create()
+    val page = pdf.startPage(pageInfo)
+    val canvas = page.canvas
+    var y = 50
+    val paint = android.graphics.Paint()
+    lessons.forEach {
+        canvas.drawText(
+            "${it.lesson.date} ${it.student.getFullName()} €%.2f".format(it.calculateFee()),
+            40f,
+            y.toFloat(),
+            paint
+        )
+        y += 20
+    }
+    pdf.finishPage(page)
+    val file = File(cacheDir, "invoice-${System.currentTimeMillis()}.pdf")
+    FileOutputStream(file).use { pdf.writeTo(it) }
+    pdf.close()
+    return Uri.fromFile(file)
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModel.kt
@@ -1,0 +1,54 @@
+package gr.tsambala.tutorbilling.ui.invoice
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class InvoiceViewModel @Inject constructor(
+    private val lessonDao: LessonDao,
+    private val studentDao: StudentDao
+) : ViewModel() {
+
+    private val _startDate = MutableStateFlow(LocalDate.now().withDayOfMonth(1))
+    private val _endDate = MutableStateFlow(LocalDate.now().withDayOfMonth(LocalDate.now().lengthOfMonth()))
+    val startDate: StateFlow<LocalDate> = _startDate.asStateFlow()
+    val endDate: StateFlow<LocalDate> = _endDate.asStateFlow()
+
+    private val _lessons = MutableStateFlow<List<LessonWithStudent>>(emptyList())
+    val lessons: StateFlow<List<LessonWithStudent>> = _lessons.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(_startDate, _endDate) { start, end -> start to end }
+                .collect { (start, end) ->
+                    combine(
+                        lessonDao.getUnpaidLessonsInDateRange(start.toString(), end.toString()),
+                        studentDao.getAllActiveStudents()
+                    ) { lessons, students ->
+                        val map = students.associateBy { it.id }
+                        lessons.mapNotNull { l -> map[l.studentId]?.let { s -> LessonWithStudent(l, s) } }
+                    }.collect { list ->
+                        _lessons.value = list
+                    }
+                }
+        }
+    }
+
+    fun updateStartDate(date: LocalDate) { _startDate.value = date }
+    fun updateEndDate(date: LocalDate) { _endDate.value = date }
+
+    fun markAsPaid(ids: List<Long>) {
+        viewModelScope.launch { lessonDao.updatePaidStatus(ids, true) }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -248,6 +248,16 @@ fun LessonScreen(
                 maxLines = 5
             )
 
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = "Paid")
+                Spacer(Modifier.width(8.dp))
+                Switch(checked = uiState.isPaid, onCheckedChange = viewModel::updatePaid)
+            }
+
             Spacer(modifier = Modifier.weight(1f))
 
             Row(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -83,7 +83,8 @@ class LessonViewModel @Inject constructor(
                                 startTime = l.startTime,
                                 durationMinutes = l.durationMinutes.toString(),
                                 notes = l.notes ?: "",
-                                isEditMode = false
+                                isEditMode = false,
+                                isPaid = l.isPaid
                             )
                         }
                     }
@@ -127,6 +128,10 @@ class LessonViewModel @Inject constructor(
         _uiState.update { it.copy(notes = notes) }
     }
 
+    fun updatePaid(paid: Boolean) {
+        _uiState.update { it.copy(isPaid = paid) }
+    }
+
     private fun isValidDate(value: String): Boolean = try {
         LocalDate.parse(value, dateFormatter)
         true
@@ -167,7 +172,8 @@ class LessonViewModel @Inject constructor(
                         date = LocalDate.parse(state.date, dateFormatter).toString(),
                         startTime = state.startTime,
                         durationMinutes = duration,
-                        notes = state.notes.ifBlank { null }
+                        notes = state.notes.ifBlank { null },
+                        isPaid = state.isPaid
                     )
                     lessonDao.insert(lesson)
                 } else {
@@ -178,7 +184,8 @@ class LessonViewModel @Inject constructor(
                             date = LocalDate.parse(state.date, dateFormatter).toString(),
                             startTime = state.startTime,
                             durationMinutes = duration,
-                            notes = state.notes.ifBlank { null }
+                            notes = state.notes.ifBlank { null },
+                            isPaid = state.isPaid
                         )
                         lessonDao.update(lesson)
                     }
@@ -220,5 +227,6 @@ data class LessonUiState(
     val studentRate: Double = 0.0,
     val availableStudents: List<Student> = emptyList(),
     val selectedStudentId: Long? = null,
-    val isEditMode: Boolean = true
+    val isEditMode: Boolean = true,
+    val isPaid: Boolean = false
 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -61,7 +61,8 @@ fun LessonsScreen(
                 items(uiState.lessons, key = { it.lesson.id }) { item ->
                     LessonItem(
                         lessonWithStudent = item,
-                        onClick = { onLessonClick(item.student.id, item.lesson.id) }
+                        onClick = { onLessonClick(item.student.id, item.lesson.id) },
+                        onPaidChange = { viewModel.updatePaid(item.lesson.id, it) }
                     )
                     Divider()
                 }
@@ -74,7 +75,8 @@ fun LessonsScreen(
 @Composable
 private fun LessonItem(
     lessonWithStudent: LessonWithStudent,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onPaidChange: (Boolean) -> Unit
 ) {
     val lesson = lessonWithStudent.lesson
     val student = lessonWithStudent.student
@@ -116,11 +118,18 @@ private fun LessonItem(
                     )
                 }
             }
-            Text(
-                text = "€%.2f".format(lessonWithStudent.calculateFee()),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "€%.2f".format(lessonWithStudent.calculateFee()),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Paid")
+                    Spacer(Modifier.width(4.dp))
+                    Checkbox(checked = lesson.isPaid, onCheckedChange = onPaidChange)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
@@ -40,6 +40,12 @@ class LessonsViewModel @Inject constructor(
             }
         }
     }
+
+    fun updatePaid(lessonId: Long, paid: Boolean) {
+        viewModelScope.launch {
+            lessonDao.updatePaidStatus(listOf(lessonId), paid)
+        }
+    }
 }
 
 data class LessonsUiState(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
@@ -18,6 +18,7 @@ import gr.tsambala.tutorbilling.utils.formatAsCurrency
 @Composable
 fun RevenueScreen(
     onBack: () -> Unit,
+    onInvoice: () -> Unit,
     viewModel: RevenueViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -25,9 +26,12 @@ fun RevenueScreen(
     val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
 
     Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = onInvoice) { Text("Invoice") }
+        },
         topBar = {
             TopAppBar(
-                title = { Text("Students") },
+                title = { Text("Revenue") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- track lesson payment status with new `isPaid` field
- add migration for `isPaid` and bump DB version
- allow marking lessons paid from lesson detail and list
- add invoice screen to share unpaid lessons as PDF
- wire up invoice screen from revenue screen
- configure FileProvider for sharing cached PDF
- fix revenue screen header

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469d20221c83308879019d3ae5dcb8