### PR TITLE
Remove duplication in Student earnings model

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/StudentWithEarnings.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/StudentWithEarnings.kt
@@ -1,0 +1,10 @@
+package gr.tsambala.tutorbilling.data.model
+
+/**
+ * Helper data class representing a student along with their earnings.
+ */
+data class StudentWithEarnings(
+    val student: Student,
+    val weekEarnings: Double,
+    val monthEarnings: Double
+)

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.data.model.StudentWithEarnings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentWithEarnings
 import gr.tsambala.tutorbilling.data.dao.StudentDao
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.model.calculateFee
@@ -80,10 +81,4 @@ class HomeViewModel @Inject constructor(
 
 data class HomeUiState(
     val students: List<StudentWithEarnings> = emptyList()
-)
-
-data class StudentWithEarnings(
-    val student: Student,
-    val weekEarnings: Double,
-    val monthEarnings: Double
 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.tsambala.tutorbilling.data.model.StudentWithEarnings
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentWithEarnings
 import gr.tsambala.tutorbilling.data.dao.StudentDao
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.model.calculateFee
@@ -107,10 +108,4 @@ class StudentsViewModel @Inject constructor(
 data class StudentsUiState(
     val students: List<StudentWithEarnings> = emptyList(),
     val searchQuery: String = ""
-)
-
-data class StudentWithEarnings(
-    val student: Student,
-    val weekEarnings: Double,
-    val monthEarnings: Double
 )


### PR DESCRIPTION
## Summary
- centralize `StudentWithEarnings` model in data layer
- update viewmodels and screens to import the shared model

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a8d2e5e48330ba9464559805e6aa