### PR TITLE
Enhance revenue and invoice workflows

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -97,12 +97,19 @@ fun TutorBillingApp(
         composable("revenue") {
             gr.tsambala.tutorbilling.ui.revenue.RevenueScreen(
                 onBack = { navController.popBackStack() },
-                onInvoice = { navController.navigate("invoice") }
+                onInvoice = { navController.navigate("invoice") },
+                onPastInvoices = { navController.navigate("pastInvoices") }
             )
         }
 
         composable("invoice") {
             gr.tsambala.tutorbilling.ui.invoice.InvoiceScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable("pastInvoices") {
+            gr.tsambala.tutorbilling.ui.invoice.PastInvoicesScreen(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
@@ -30,6 +30,12 @@ interface LessonDao {
     @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate ORDER BY date DESC, startTime DESC")
     fun getLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>>
 
+    @Query("SELECT * FROM lessons WHERE studentId = :studentId AND date BETWEEN :startDate AND :endDate ORDER BY date ASC")
+    fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<Lesson>>
+
+    @Query("SELECT * FROM lessons WHERE studentId = :studentId AND date BETWEEN :startDate AND :endDate AND isPaid = 0 ORDER BY date ASC")
+    fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<Lesson>>
+
     @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate AND isPaid = 0 ORDER BY date ASC")
     fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>>
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -7,15 +7,20 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Checkbox
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.menuAnchor
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.content.FileProvider
@@ -35,6 +40,9 @@ fun InvoiceScreen(
     val startDate by viewModel.startDate.collectAsStateWithLifecycle()
     val endDate by viewModel.endDate.collectAsStateWithLifecycle()
     val lessons by viewModel.lessons.collectAsStateWithLifecycle()
+    val students by viewModel.students.collectAsStateWithLifecycle()
+    val selectedStudentId by viewModel.selectedStudentId.collectAsStateWithLifecycle()
+    val selectedLessons by viewModel.selectedLessons.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     Scaffold(
@@ -43,7 +51,7 @@ fun InvoiceScreen(
                 title = { Text("Invoice") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
@@ -58,7 +66,8 @@ fun InvoiceScreen(
                 OutlinedButton(onClick = onBack, modifier = Modifier.weight(1f)) { Text("Cancel") }
                 Button(
                     onClick = {
-                        val uri = createInvoicePdf(context.cacheDir, lessons)
+                        val selected = lessons.filter { selectedLessons.contains(it.lesson.id) }
+                        val uri = createInvoicePdf(File(context.filesDir, "invoices"), selected)
                         val share = Intent(Intent.ACTION_SEND).apply {
                             type = "application/pdf"
                             putExtra(Intent.EXTRA_STREAM, FileProvider.getUriForFile(context, "${context.packageName}.provider", File(uri.path!!)))
@@ -67,23 +76,34 @@ fun InvoiceScreen(
                         context.startActivity(Intent.createChooser(share, null))
                     },
                     modifier = Modifier.weight(1f),
-                    enabled = lessons.isNotEmpty()
+                    enabled = selectedLessons.isNotEmpty()
                 ) { Text("Share PDF") }
             }
         }
     ) { padding ->
         Column(Modifier.padding(padding).padding(16.dp)) {
+            StudentDropdown(students, selectedStudentId, onSelect = viewModel::selectStudent)
             DateField("Start", startDate) { date -> viewModel.updateStartDate(date) }
             DateField("End", endDate) { date -> viewModel.updateEndDate(date) }
 
+            if (lessons.isNotEmpty()) {
+                TextButton(onClick = { viewModel.selectAll() }) {
+                    Text("Select All")
+                }
+            }
+
             if (lessons.isEmpty()) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("No unpaid lessons")
+                    Text("No lessons")
                 }
             } else {
                 LazyColumn(modifier = Modifier.weight(1f)) {
                     items(lessons) { item ->
-                        LessonRow(item)
+                        LessonRow(
+                            item = item,
+                            checked = selectedLessons.contains(item.lesson.id),
+                            onToggle = { viewModel.toggleLesson(item.lesson.id) }
+                        )
                         Divider()
                     }
                 }
@@ -93,18 +113,23 @@ fun InvoiceScreen(
 }
 
 @Composable
-private fun LessonRow(item: LessonWithStudent) {
+private fun LessonRow(item: LessonWithStudent, checked: Boolean, onToggle: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Column {
             Text(item.student.getFullName(), style = MaterialTheme.typography.bodyMedium)
             Text(LocalDate.parse(item.lesson.date).format(DateTimeFormatter.ofPattern("dd MMM")))
         }
-        Text("€%.2f".format(item.calculateFee()))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("€%.2f".format(item.calculateFee()))
+            Spacer(Modifier.width(8.dp))
+            Checkbox(checked = checked, onCheckedChange = { onToggle() })
+        }
     }
 }
 
@@ -130,7 +155,7 @@ private fun DateField(label: String, date: LocalDate, onDate: (LocalDate) -> Uni
     )
 }
 
-fun createInvoicePdf(cacheDir: File, lessons: List<LessonWithStudent>): Uri {
+fun createInvoicePdf(directory: File, lessons: List<LessonWithStudent>): Uri {
     val pdf = android.graphics.pdf.PdfDocument()
     val pageInfo = android.graphics.pdf.PdfDocument.PageInfo.Builder(595, 842, 1).create()
     val page = pdf.startPage(pageInfo)
@@ -147,8 +172,32 @@ fun createInvoicePdf(cacheDir: File, lessons: List<LessonWithStudent>): Uri {
         y += 20
     }
     pdf.finishPage(page)
-    val file = File(cacheDir, "invoice-${System.currentTimeMillis()}.pdf")
+    if (!directory.exists()) directory.mkdirs()
+    val file = File(directory, "invoice-${System.currentTimeMillis()}.pdf")
     FileOutputStream(file).use { pdf.writeTo(it) }
     pdf.close()
     return Uri.fromFile(file)
+}
+
+@Composable
+private fun StudentDropdown(students: List<gr.tsambala.tutorbilling.data.model.Student>, selectedId: Long?, onSelect: (Long) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+        OutlinedTextField(
+            value = students.firstOrNull { it.id == selectedId }?.getFullName() ?: "",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Student") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true).fillMaxWidth()
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            students.forEach { student ->
+                DropdownMenuItem(text = { Text(student.getFullName()) }, onClick = {
+                    onSelect(student.id)
+                    expanded = false
+                })
+            }
+        }
+    }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
@@ -1,0 +1,62 @@
+package gr.tsambala.tutorbilling.ui.invoice
+
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import java.io.File
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PastInvoicesScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val invoicesDir = remember { File(context.filesDir, "invoices") }
+    val invoices = remember { invoicesDir.listFiles()?.sortedByDescending { it.lastModified() } ?: emptyList() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Past Invoices") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (invoices.isEmpty()) {
+            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Text("No invoices found")
+            }
+        } else {
+            LazyColumn(Modifier.fillMaxSize().padding(padding)) {
+                items(invoices) { file ->
+                    ListItem(
+                        headlineText = { Text(file.name) },
+                        modifier = Modifier.clickable {
+                            val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
+                            val intent = Intent(Intent.ACTION_VIEW).apply {
+                                setDataAndType(uri, "application/pdf")
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            }
+                            context.startActivity(intent)
+                        }
+                    )
+                    Divider()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
@@ -19,6 +19,7 @@ import gr.tsambala.tutorbilling.utils.formatAsCurrency
 fun RevenueScreen(
     onBack: () -> Unit,
     onInvoice: () -> Unit,
+    onPastInvoices: () -> Unit,
     viewModel: RevenueViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
@@ -26,9 +27,6 @@ fun RevenueScreen(
     val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
 
     Scaffold(
-        floatingActionButton = {
-            FloatingActionButton(onClick = onInvoice) { Text("Invoice") }
-        },
         topBar = {
             TopAppBar(
                 title = { Text("Revenue") },
@@ -82,6 +80,45 @@ fun RevenueScreen(
                     modifier = Modifier.weight(1f),
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer
                 )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                MetricTile(
+                    label = "Unpaid",
+                    value = uiState.monthlyUnpaid.formatAsCurrency(
+                        settings.currencySymbol,
+                        settings.roundingDecimals
+                    ),
+                    modifier = Modifier.weight(1f),
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                )
+                MetricTile(
+                    label = "Paid",
+                    value = uiState.monthlyPaid.formatAsCurrency(
+                        settings.currencySymbol,
+                        settings.roundingDecimals
+                    ),
+                    modifier = Modifier.weight(1f),
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = onInvoice,
+                    modifier = Modifier.weight(1f)
+                ) { Text("New Invoice") }
+                OutlinedButton(
+                    onClick = onPastInvoices,
+                    modifier = Modifier.weight(1f)
+                ) { Text("Past Invoices") }
             }
         }
     }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="cache" path="." />
+    <files-path name="invoices" path="invoices/" />
 </paths>


### PR DESCRIPTION
## Summary
- calculate paid and unpaid monthly totals
- display monthly paid/unpaid revenue and invoice action buttons
- select student and lessons when building an invoice
- store and list generated invoices
- expose invoice directory through file provider
- add navigation to view past invoices

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae4834b083309a5503e6ef99568c