### PR TITLE
Clamp rounding decimals within 0..2

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/settings/SettingsRepository.kt
@@ -33,7 +33,7 @@ class SettingsRepository @Inject constructor(
     val settings: Flow<AppSettings> = context.settingsDataStore.data.map { prefs ->
         AppSettings(
             currencySymbol = prefs[Keys.CURRENCY] ?: "€",
-            roundingDecimals = prefs[Keys.ROUNDING] ?: 2,
+            roundingDecimals = (prefs[Keys.ROUNDING] ?: 2).coerceIn(0, 2),
             darkTheme = prefs[Keys.DARK_THEME] ?: false
         )
     }
@@ -43,7 +43,7 @@ class SettingsRepository @Inject constructor(
     }
 
     suspend fun setRounding(decimals: Int) {
-        context.settingsDataStore.edit { it[Keys.ROUNDING] = decimals }
+        context.settingsDataStore.edit { it[Keys.ROUNDING] = decimals.coerceIn(0, 2) }
     }
 
     suspend fun setDarkTheme(enabled: Boolean) {


### PR DESCRIPTION
## Summary
- clamp stored rounding decimals to range 0..2
- persist clamped value for rounding setting

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd67f65c8330848345124bd6096a