### PR TITLE
Add date index migration

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -54,3 +54,11 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
         database.execSQL("ALTER TABLE lessons ADD COLUMN isPaid INTEGER NOT NULL DEFAULT 0")
     }
 }
+
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "CREATE INDEX IF NOT EXISTS index_lessons_date ON lessons(date)"
+        )
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -10,7 +10,7 @@ import gr.tsambala.tutorbilling.data.model.Lesson
 
 @Database(
     entities = [Student::class, Lesson::class],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(DateTimeConverters::class)

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
@@ -15,7 +15,7 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("studentId")]
+    indices = [Index("studentId"), Index("date")]
 )
 data class Lesson(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
@@ -14,6 +14,7 @@ import gr.tsambala.tutorbilling.data.database.MIGRATION_1_2
 import gr.tsambala.tutorbilling.data.database.MIGRATION_2_3
 import gr.tsambala.tutorbilling.data.database.MIGRATION_3_4
 import gr.tsambala.tutorbilling.data.database.MIGRATION_4_5
+import gr.tsambala.tutorbilling.data.database.MIGRATION_5_6
 import javax.inject.Singleton
 
 @Module
@@ -30,7 +31,13 @@ object DatabaseModule {
             TutorBillingDatabase::class.java,
             "tutor_billing_database"
         )
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+            .addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                MIGRATION_5_6
+            )
             .build()
     }
 


### PR DESCRIPTION
## Summary
- index Lesson `date` field
- add MIGRATION_5_6 and bump DB version
- register migrations with Hilt module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9a35ef0833093e7916671a82578