### PR TITLE
Remove unused import from InvoiceScreen

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -25,7 +25,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.content.FileProvider
 import gr.tsambala.tutorbilling.data.database.LessonWithStudent
-import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.io.FileOutputStream
 import java.time.LocalDate


### PR DESCRIPTION
## Summary
- remove unnecessary `runBlocking` import
- reformat invoice screen file

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9a4ba6c833096eda4ec33865853