### PR TITLE
Add default proguard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,23 @@
+# ProGuard rules for TutorBillingApp
+
+# Keep classes annotated with Hilt entry points so Dagger can generate and locate them
+-keep @dagger.hilt.android.HiltAndroidApp class *
+-keep @dagger.hilt.android.AndroidEntryPoint class *
+
+# Keep generated Hilt components and internal managers
+-keep class dagger.hilt.** { *; }
+-keep class javax.inject.** { *; }
+
+# Jetpack Compose requires keeping composable methods and related runtime classes
+-keep class androidx.compose.** { *; }
+-keepclassmembers class * {
+    @androidx.compose.runtime.Composable <methods>;
+}
+
+# Keep Room annotations and generated schema classes
+-keep @androidx.room.* class *
+-keep class androidx.room.** { *; }
+-keepclassmembers class * {
+    @androidx.room.* <fields>;
+    @androidx.room.* <methods>;
+}


### PR DESCRIPTION
## Summary
- add a new `proguard-rules.pro` with keep rules for Hilt, Compose and Room

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9a241dc83309cfbfe067aa28824