### PR TITLE
Move inline strings to resources

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,7 +55,7 @@ fun HomeScreen(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = "No students yet.\nTap + to add your first student.",
+                    text = stringResource(R.string.no_students),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MenuAnchorType
@@ -94,7 +95,7 @@ fun InvoiceScreen(
 
             if (lessons.isEmpty()) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("No lessons")
+                    Text(stringResource(R.string.no_lessons_short))
                 }
             } else {
                 LazyColumn(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -38,7 +39,7 @@ fun PastInvoicesScreen(onBack: () -> Unit) {
     ) { padding ->
         if (invoices.isEmpty()) {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
-                Text("No invoices found")
+                Text(stringResource(R.string.no_invoices))
             }
         } else {
             LazyColumn(Modifier.fillMaxSize().padding(padding)) {

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -238,7 +239,7 @@ fun LessonScreen(
             OutlinedTextField(
                 value = uiState.notes,
                 onValueChange = viewModel::updateNotes,
-                label = { Text("Notes (optional)") },
+                label = { Text(stringResource(R.string.lesson_note)) },
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 3,
                 maxLines = 5

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -51,7 +52,7 @@ fun LessonsScreen(
                     .padding(padding),
                 contentAlignment = Alignment.Center
             ) {
-                Text(text = "No lessons recorded yet")
+                Text(text = stringResource(R.string.no_lessons))
             }
         } else {
             LazyColumn(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -266,7 +267,7 @@ private fun StudentDetailView(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = "No lessons yet.\nTap + to add a lesson.",
+                        text = stringResource(R.string.no_lessons_prompt),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -88,7 +89,7 @@ fun StudentsScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = "No students yet.\nTap + to add your first student.",
+                            text = stringResource(R.string.no_students),
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,9 @@
     <string name="lesson_duration">Duration (minutes)</string>
     <string name="lesson_note">Note (optional)</string>
     <string name="no_lessons">No lessons recorded yet</string>
+    <string name="no_lessons_prompt">No lessons yet. Tap + to add a lesson.</string>
+    <string name="no_lessons_short">No lessons</string>
+    <string name="no_invoices">No invoices found</string>
     <string name="lessons">Lessons</string>
 
     <!-- Financial summary strings -->


### PR DESCRIPTION
## Summary
- add missing string resources like `no_invoices` and `no_lessons_prompt`
- replace hardcoded Compose text with `stringResource`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d9a4edc48330b29d03b52375fa96