### PR TITLE
Clean up unused utilities

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -1,13 +1,11 @@
 package gr.tsambala.tutorbilling.utils
 
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-import java.time.temporal.WeekFields
-import java.util.Locale
-import java.text.DecimalFormat
-import java.text.DecimalFormatSymbols
 
 /**
  * AppUtils contains utility functions and extension methods used throughout the app.
@@ -29,7 +27,6 @@ import java.text.DecimalFormatSymbols
  * - 0.0 -> "€0.00"
  */
 fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
-
     // Clamp decimals to 0..2
     val safeDecimals = decimals.coerceIn(0, 2)
 
@@ -40,17 +37,6 @@ fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
         maximumFractionDigits = safeDecimals
     }
     return formatter.format(this)
-}
-
-/**
- * Formats a nullable Double as currency, returning a default for null values.
- */
-fun Double?.formatAsCurrencyOrDefault(symbol: String = "€", decimals: Int = 2): String {
-
-    val safeDecimals = decimals.coerceIn(0, 2)
-
-    val default = 0.0.formatAsCurrency(symbol, safeDecimals)
-    return this?.formatAsCurrency(symbol, safeDecimals) ?: default
 }
 
 // ===== Date Formatting =====
@@ -65,59 +51,6 @@ fun Double?.formatAsCurrencyOrDefault(symbol: String = "€", decimals: Int = 2)
  */
 fun LocalDate.formatForDisplay(): String {
     return format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM))
-}
-
-/**
- * Formats a LocalDate in a short format for compact display.
- * Useful in lists or cards where space is limited.
- *
- * Examples:
- * - 2024-03-15 -> "15/03"
- * - 2024-12-25 -> "25/12"
- */
-fun LocalDate.formatShort(): String {
-    return format(DateTimeFormatter.ofPattern("dd/MM"))
-}
-
-/**
- * Checks if this date is in the current week.
- * Uses the system's locale to determine week boundaries.
- */
-fun LocalDate.isInCurrentWeek(): Boolean {
-    val now = LocalDate.now()
-    val weekFields = WeekFields.of(Locale.getDefault())
-    return this.get(weekFields.weekOfWeekBasedYear()) == now.get(weekFields.weekOfWeekBasedYear()) &&
-            this.year == now.year
-}
-
-/**
- * Checks if this date is in the current month.
- */
-fun LocalDate.isInCurrentMonth(): Boolean {
-    val now = LocalDate.now()
-    return this.month == now.month && this.year == now.year
-}
-
-/**
- * Gets a human-readable relative date string.
- *
- * Examples:
- * - Today -> "Today"
- * - Yesterday -> "Yesterday"
- * - Within 7 days -> "Monday" (or appropriate day name)
- * - Otherwise -> "Mar 15" (formatted date)
- */
-fun LocalDate.toRelativeString(): String {
-    val today = LocalDate.now()
-    return when (this) {
-        today -> "Today"
-        today.minusDays(1) -> "Yesterday"
-        today.plusDays(1) -> "Tomorrow"
-        in today.minusDays(7)..today.plusDays(7) -> {
-            format(DateTimeFormatter.ofPattern("EEEE"))
-        }
-        else -> formatForDisplay()
-    }
 }
 
 // ===== Time Formatting =====
@@ -147,86 +80,6 @@ fun LocalTime.format12Hour(): String {
     return format(DateTimeFormatter.ofPattern("h:mm a"))
 }
 
-// ===== Duration Formatting =====
-
-/**
- * Formats minutes as a human-readable duration.
- *
- * Examples:
- * - 30 -> "30m"
- * - 60 -> "1h"
- * - 90 -> "1h 30m"
- * - 150 -> "2h 30m"
- */
-fun Int.formatAsDuration(): String {
-    val hours = this / 60
-    val minutes = this % 60
-
-    return when {
-        hours == 0 -> "${minutes}m"
-        minutes == 0 -> "${hours}h"
-        else -> "${hours}h ${minutes}m"
-    }
-}
-
-/**
- * Converts minutes to decimal hours for calculations.
- *
- * Examples:
- * - 30 -> 0.5
- * - 60 -> 1.0
- * - 90 -> 1.5
- */
-fun Int.toDecimalHours(): Double {
-    return this / 60.0
-}
-
-// ===== Validation Extensions =====
-
-/**
- * Validates if a string can be parsed as a positive double.
- * Useful for validating rate inputs.
- */
-fun String.isValidPositiveDouble(): Boolean {
-    return toDoubleOrNull()?.let { it > 0 } ?: false
-}
-
-/**
- * Validates if a string can be parsed as a positive integer.
- * Useful for validating duration inputs.
- */
-fun String.isValidPositiveInt(): Boolean {
-    return toIntOrNull()?.let { it > 0 } ?: false
-}
-
-/**
- * Safely converts a string to Double with a default value.
- */
-fun String.toDoubleOrDefault(default: Double = 0.0): Double {
-    return toDoubleOrNull() ?: default
-}
-
-/**
- * Safely converts a string to Int with a default value.
- */
-fun String.toIntOrDefault(default: Int = 0): Int {
-    return toIntOrNull() ?: default
-}
-
-// ===== String Extensions =====
-
-/**
- * Truncates a string to a maximum length with ellipsis.
- * Useful for displaying long text in limited space.
- *
- * Examples:
- * - "Short text".truncate(20) -> "Short text"
- * - "This is a very long text".truncate(10) -> "This is a..."
- */
-fun String.truncate(maxLength: Int): String {
-    return if (length <= maxLength) this else "${take(maxLength - 3)}..."
-}
-
 /**
  * Capitalizes the first letter of each word.
  * Useful for formatting names.
@@ -239,27 +92,3 @@ fun String.titleCase(): String {
         word.lowercase().replaceFirstChar { it.uppercase() }
     }
 }
-
-// ===== Constants =====
-
-/**
- * App-wide constants for consistency.
- */
-    // Validation limits
-    const val MAX_STUDENT_NAME_LENGTH = 100
-    const val MAX_LESSON_DURATION_MINUTES = 480 // 8 hours
-    const val MIN_LESSON_DURATION_MINUTES = 5
-    const val MAX_LESSON_NOTES_LENGTH = 500
-
-    // UI Constants
-    const val SEARCH_DEBOUNCE_DELAY_MS = 300L
-    const val ANIMATION_DURATION_MS = 300
-
-    // Default values
-    const val DEFAULT_LESSON_DURATION_MINUTES = 60
-    const val DEFAULT_HOURLY_RATE = 25.0
-
-    // Date/Time patterns
-    const val DATE_PATTERN_DISPLAY = "dd MMM yyyy"
-    const val TIME_PATTERN_24H = "HH:mm"
-    const val TIME_PATTERN_12H = "h:mm a"


### PR DESCRIPTION
## Summary
- remove unused helper functions and constants from `AppUtils`
- keep only currency formatting, date/time helpers that are used, and `titleCase`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846de5742408330bc9715ca240e4c67