### PR TITLE
Fix missing Material theme attrs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,11 +52,13 @@ android {
     }
 }
 
-dependencies {
-    // Core Android
-    implementation 'androidx.core:core-ktx:1.16.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.1'
-    implementation 'androidx.activity:activity-compose:1.10.1'
+    dependencies {
+        // Core Android
+        implementation 'androidx.core:core-ktx:1.16.0'
+        implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.1'
+        implementation 'androidx.activity:activity-compose:1.10.1'
+        // Material Components (for XML themes)
+        implementation 'com.google.android.material:material:1.12.0'
     // Jetpack Compose
     implementation platform("androidx.compose:compose-bom:2025.06.00")
     implementation "androidx.compose.material3:material3"


### PR DESCRIPTION
## Summary
- add Material Components library dependency for XML themes

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e24968bc8330894bbc0bc89bd28a