### PR TITLE
Switch to compose date/time pickers

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/components/ClickableReadOnlyField.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/components/ClickableReadOnlyField.kt
@@ -1,0 +1,34 @@
+package gr.tsambala.tutorbilling.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ClickableReadOnlyField(
+    value: String,
+    onClick: () -> Unit,
+    label: @Composable (() -> Unit)? = null,
+    singleLine: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = {},
+            readOnly = true,
+            label = label,
+            singleLine = singleLine,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Box(
+            Modifier
+                .matchParentSize()
+                .clickable(onClick = onClick)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClickableReadOnlyField` composable to overlay clickable areas
- use Material3 `DatePickerDialog` and `TimePickerDialog`
- replace date/time fields with `ClickableReadOnlyField`
- update invoice date field similarly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e1f5a2f083308f1f7c9e5f62129a