### PR TITLE
Add missing R imports in screens

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.home
 
+import gr.tsambala.tutorbilling.R
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.invoice
 
+import gr.tsambala.tutorbilling.R
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.invoice
 
+import gr.tsambala.tutorbilling.R
 import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.lesson
 
+import gr.tsambala.tutorbilling.R
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.lessons
 
+import gr.tsambala.tutorbilling.R
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.student
 
+import gr.tsambala.tutorbilling.R
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.rememberScrollState

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
@@ -1,5 +1,6 @@
 package gr.tsambala.tutorbilling.ui.students
 
+import gr.tsambala.tutorbilling.R
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn


### PR DESCRIPTION
## Summary
- add `import gr.tsambala.tutorbilling.R` at the top of all screen files referencing `R.string.*`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e78ab9ac8330b04ebf7362f980be