### PR TITLE
Add extended icons dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ android {
     implementation "androidx.compose.ui:ui-tooling-preview"
     implementation "androidx.compose.ui:ui-graphics"
     implementation "androidx.compose.material:material-icons-core"
+    implementation "androidx.compose.material:material-icons-extended"
     implementation "androidx.compose.foundation:foundation"
     debugImplementation "androidx.compose.ui:ui-tooling"
     debugImplementation "androidx.compose.ui:ui-test-manifest"


### PR DESCRIPTION
## Summary
- include `material-icons-extended` to support `Icons.AutoMirrored.Filled.Sort`

## Testing
- `gradlew --version`
- `gradlew :app:compileDebugKotlin` *(fails: Calculating task graph)*

------
https://chatgpt.com/codex/tasks/task_e_6846e78b8890833098146a94748b375b