### PR TITLE
Clamp currency decimals via DecimalFormat

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -27,15 +27,24 @@ import java.time.format.FormatStyle
  * - 0.0 -> "€0.00"
  */
 fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
-    // Clamp decimals to 0..2
+    // Clamp decimals to a sensible range to avoid invalid patterns
     val safeDecimals = decimals.coerceIn(0, 2)
 
     val symbols = DecimalFormatSymbols().apply { currencySymbol = symbol }
-    val pattern = "#,##0.${"0".repeat(safeDecimals)}"
+
+    val pattern = buildString {
+        append("#,##0")
+        if (safeDecimals > 0) {
+            append('.')
+            repeat(safeDecimals) { append('0') }
+        }
+    }
+
     val formatter = DecimalFormat(pattern, symbols).apply {
         minimumFractionDigits = safeDecimals
         maximumFractionDigits = safeDecimals
     }
+
     return formatter.format(this)
 }
 


### PR DESCRIPTION
## Summary
- fix `formatAsCurrency` to build a valid pattern when decimals is 0

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708b3639c8330a96bb975925d5824