### PR TITLE
Ensure student deletion returns to Main dispatcher

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
@@ -14,6 +14,7 @@ import android.util.Patterns
 import gr.tsambala.tutorbilling.utils.titleCase
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.temporal.WeekFields
 import java.util.Locale
@@ -190,7 +191,9 @@ class StudentViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             studentId?.toLongOrNull()?.let { id ->
                 studentDao.softDeleteStudent(id)
-                onDeleted()
+                withContext(Dispatchers.Main) {
+                    onDeleted()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep UI actions on the main dispatcher after student deletion

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708b6868883309203f56901175142