### PR TITLE
Fix MIGRATION_5_6 default

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -61,7 +61,7 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
                 "startTime TEXT NOT NULL," +
                 "durationMinutes INTEGER NOT NULL," +
                 "notes TEXT," +
-                "isPaid INTEGER NOT NULL DEFAULT 1," +
+                "isPaid INTEGER NOT NULL DEFAULT 0," +
                 "FOREIGN KEY(studentId) REFERENCES students(id) ON DELETE CASCADE)"
         )
 

--- a/app/src/test/java/gr/tsambala/tutorbilling/data/database/MigrationsTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/data/database/MigrationsTest.kt
@@ -104,7 +104,7 @@ class MigrationsTest {
             it.getInt(0)
         }
 
-        assertTrue(defaultValue?.contains("1") == true && count == 1)
+        assertTrue(defaultValue?.contains("0") == true && count == 1)
 
         db.close()
     }


### PR DESCRIPTION
## Summary
- set default value for `isPaid` to `0` in migration 5→6 so it matches the `Lesson` entity
- update migration test accordingly

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afdffdac83308964aa5f8920b4b5