### PR TITLE
Remove kapt worker options

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,6 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 # Kapt (Kotlin Annotation Processing Tool) settings for better performance
-kapt.use.worker.api=true
-kapt.incremental.apt=true
 
 # Kotlin code style
 kotlin.code.style=official


### PR DESCRIPTION
## Summary
- remove `kapt.use.worker.api` and `kapt.incremental.apt` from `gradle.properties`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848afe0e3608330b56bf550f3afd2a2