### PR TITLE
Add Room default annotations

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
@@ -1,6 +1,7 @@
 // Lesson.kt - Fixed data model with proper defaults
 package gr.tsambala.tutorbilling.data.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
@@ -31,6 +32,7 @@ data class Lesson(
     val startTime: String, // Store as time string (HH:mm)
     val durationMinutes: Int,
     val notes: String? = null,
+    @ColumnInfo(defaultValue = "0")
     val isPaid: Boolean = false // Default to false (0 in database)
 ) {
     // Helper functions for date/time conversion

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/Student.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/Student.kt
@@ -1,6 +1,7 @@
 // Student.kt - Fixed data model
 package gr.tsambala.tutorbilling.data.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -10,5 +11,6 @@ data class Student(
     val id: Long = 0,
     val name: String,
     val rate: Double, // Hourly rate in euros
+    @ColumnInfo(defaultValue = "1")
     val isActive: Boolean = true // Default to active
 )


### PR DESCRIPTION
## Summary
- specify default boolean values for `isActive` and `isPaid`
- keep migrations using the same defaults

## Testing
- `./gradlew test --console=plain` *(fails: ksp Release/Debug Kotlin compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848c769e88c83309ed43418465fa549