### PR TITLE
Fix lesson delete callback threading

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -12,6 +12,7 @@ import gr.tsambala.tutorbilling.data.model.RateTypes
 import gr.tsambala.tutorbilling.data.model.Student
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -200,7 +201,9 @@ class LessonViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             lessonId?.toLongOrNull()?.let { id ->
                 lessonDao.deleteById(id)
-                onDeleted()
+                withContext(Dispatchers.Main) {
+                    onDeleted()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure `LessonViewModel.deleteLesson` invokes its callback on the main thread

## Testing
- `./gradlew test` *(fails: Task :app:kspReleaseKotlin FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6848c76e05508330a4760ee7833260b8