### PR TITLE
Use numeric lesson navigation args

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -90,8 +90,8 @@ fun TutorBillingApp() {
             val studentId = backStackEntry.arguments?.getLong("studentId") ?: 0L
 
             LessonScreen(
-                studentId = studentId.toString(),
-                lessonId = if (lessonId == 0L) "new" else lessonId.toString(),
+                studentId = studentId.takeIf { it != 0L },
+                lessonId = lessonId,
                 onNavigateBack = { navController.popBackStack() },
                 viewModel = viewModel
             )

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -29,8 +29,8 @@ import java.time.format.DateTimeFormatter
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LessonScreen(
-    studentId: String?,
-    lessonId: String?,
+    studentId: Long?,
+    lessonId: Long,
     onNavigateBack: () -> Unit,
     viewModel: LessonViewModel = hiltViewModel()
 ) {
@@ -41,7 +41,7 @@ fun LessonScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = if (lessonId == "new") "Add Lesson" else "Edit Lesson"
+                        text = if (lessonId == 0L) "Add Lesson" else "Edit Lesson"
                     )
                 },
                 navigationIcon = {
@@ -51,7 +51,7 @@ fun LessonScreen(
                 },
                 actions = {
                     var showDelete by remember { mutableStateOf(false) }
-                    if (lessonId != "new") {
+                    if (lessonId != 0L) {
                         IconButton(onClick = { showDelete = true }) {
                             Icon(Icons.Default.Delete, contentDescription = "Delete")
                         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -27,15 +27,15 @@ class LessonViewModel @Inject constructor(
     private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
-    private val studentId: String? = savedStateHandle.get<String>("studentId")
-    private val lessonId: String? = savedStateHandle.get<String>("lessonId")
+    private val studentId: Long? = savedStateHandle.get<Long>("studentId")
+    private val lessonId: Long? = savedStateHandle.get<Long>("lessonId")
 
     private val _uiState = MutableStateFlow(LessonUiState())
     val uiState: StateFlow<LessonUiState> = _uiState.asStateFlow()
 
     init {
         loadStudentInfo()
-        if (lessonId != null && lessonId != "new") {
+        if (lessonId != null && lessonId != 0L) {
             loadLesson()
         } else {
             // Set default values for new lesson
@@ -50,7 +50,7 @@ class LessonViewModel @Inject constructor(
 
     private fun loadStudentInfo() {
         viewModelScope.launch(Dispatchers.IO) {
-            val id = studentId?.toLongOrNull()
+            val id = studentId?.takeIf { it != 0L }
             if (id != null) {
                 studentDao.getStudentById(id).collect { student ->
                     student?.let { s ->
@@ -73,7 +73,7 @@ class LessonViewModel @Inject constructor(
 
     private fun loadLesson() {
         viewModelScope.launch(Dispatchers.IO) {
-            lessonId?.toLongOrNull()?.let { id ->
+            lessonId?.takeIf { it != 0L }?.let { id ->
                 lessonDao.getLessonById(id).collect { lesson ->
                     lesson?.let { l ->
                         _uiState.update { state ->
@@ -162,7 +162,7 @@ class LessonViewModel @Inject constructor(
 
             val sId = state.selectedStudentId
             sId?.let {
-                if (lessonId == "new") {
+                if (lessonId == null || lessonId == 0L) {
                     val lesson = Lesson(
                         studentId = it,
                         date = LocalDate.parse(state.date, dateFormatter).toString(),
@@ -173,7 +173,7 @@ class LessonViewModel @Inject constructor(
                     )
                     lessonDao.insert(lesson)
                 } else {
-                    lessonId?.toLongOrNull()?.let { lId ->
+                    lessonId?.let { lId ->
                         val lesson = Lesson(
                             id = lId,
                             studentId = it,
@@ -194,7 +194,7 @@ class LessonViewModel @Inject constructor(
 
     fun deleteLesson(onDeleted: () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
-            lessonId?.toLongOrNull()?.let { id ->
+            lessonId?.takeIf { it != 0L }?.let { id ->
                 lessonDao.deleteById(id)
                 withContext(Dispatchers.Main) {
                     onDeleted()


### PR DESCRIPTION
## Summary
- treat navigation arguments as `Long` values instead of Strings
- update LessonViewModel to work with numeric IDs
- update LessonScreen and navigation host to match

## Testing
- `./gradlew test` *(fails: ModuleProcessingStep error)*

------
https://chatgpt.com/codex/tasks/task_e_6849636a4010833088a1f843746e5ed0