### PR TITLE
Ensure sanitized duration used for validation

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -158,6 +158,7 @@ class LessonViewModel @Inject constructor(
             var duration = state.durationMinutes.toIntOrNull() ?: 0
             if (duration <= 0) duration = 60
             if (duration < 60) duration = 60
+            _uiState.update { it.copy(durationMinutes = duration.toString()) }
             if (!isFormValid()) return@launch
 
             val sId = state.selectedStudentId


### PR DESCRIPTION
## Summary
- sanitize the duration and update `_uiState` before calling `isFormValid`

## Testing
- `./gradlew test --console=plain` *(fails: ModuleProcessingStep errors)*

------
https://chatgpt.com/codex/tasks/task_e_684966d5d9c08330aca34b5cddbdacda