### PR TITLE
Add navigation callback to LessonViewModel

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -86,6 +86,13 @@ fun TutorBillingApp() {
         ) { backStackEntry ->
             val viewModel: LessonViewModel = hiltViewModel()
 
+            // Set up navigation callback
+            LaunchedEffect(Unit) {
+                viewModel.setNavigationCallback {
+                    navController.popBackStack()
+                }
+            }
+
             val lessonId = backStackEntry.arguments?.getLong("lessonId") ?: 0L
             val studentId = backStackEntry.arguments?.getLong("studentId") ?: 0L
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -64,7 +64,7 @@ fun LessonScreen(
                             text = { Text("Are you sure you want to delete this lesson?") },
                             confirmButton = {
                                 TextButton(onClick = {
-                                    viewModel.deleteLesson(onNavigateBack)
+                                    viewModel.deleteLesson()
                                     showDelete = false
                                 }) {
                                     Text("Delete", color = MaterialTheme.colorScheme.error)
@@ -280,7 +280,9 @@ fun LessonScreen(
                 Button(
                     onClick = {
                         viewModel.saveLesson()
-                        onNavigateBack()
+                        if (lessonId == 0L) {
+                            onNavigateBack()
+                        }
                     },
                     modifier = Modifier.weight(1f),
                     enabled = viewModel.isFormValid()

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -33,6 +33,13 @@ class LessonViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LessonUiState())
     val uiState: StateFlow<LessonUiState> = _uiState.asStateFlow()
 
+    // Navigation callback
+    private var onNavigateBack: (() -> Unit)? = null
+
+    fun setNavigationCallback(callback: () -> Unit) {
+        onNavigateBack = callback
+    }
+
     init {
         loadStudentInfo()
         if (lessonId != null && lessonId != 0L) {
@@ -189,15 +196,22 @@ class LessonViewModel @Inject constructor(
             }
 
             _uiState.update { it.copy(isEditMode = false) }
+
+            // Navigate back on main thread
+            withContext(Dispatchers.Main) {
+                onNavigateBack?.invoke()
+            }
         }
     }
 
-    fun deleteLesson(onDeleted: () -> Unit) {
+    fun deleteLesson() {
         viewModelScope.launch(Dispatchers.IO) {
             lessonId?.takeIf { it != 0L }?.let { id ->
                 lessonDao.deleteById(id)
+
+                // Navigate back on main thread
                 withContext(Dispatchers.Main) {
-                    onDeleted()
+                    onNavigateBack?.invoke()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- support navigation callback in `LessonViewModel`
- invoke callback after saving or deleting a lesson
- set callback in `TutorBillingApp`
- update `LessonScreen` to use new ViewModel navigation

## Testing
- `./gradlew assembleDebug` *(fails: error.NonExistentClass)*
- `./gradlew testDebugUnitTest` *(fails: error.NonExistentClass)*

------
https://chatgpt.com/codex/tasks/task_e_684966d52db88330a971ebc3f76796c7