### PR TITLE
Unify new lesson marker

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -30,7 +30,7 @@ fun TutorBillingApp() {
                 onClassesClick = { navController.navigate("classes") },
                 onNavigateToLesson = { navController.navigate("lessons") },
                 onNavigateToNewStudent = { navController.navigate("student/0") },
-                onNavigateToNewLesson = { navController.navigate("lesson/0") },
+                onNavigateToNewLesson = { navController.navigate("lesson/new") },
                 onRevenue = { navController.navigate("revenue") },
                 onSettings = { navController.navigate("settings") }
             )
@@ -65,7 +65,7 @@ fun TutorBillingApp() {
                     navController.navigate("lesson/$lessonId?studentId=$studentIdArg")
                 },
                 onAddLesson = {
-                    navController.navigate("lesson/0?studentId=$studentIdArg")
+                    navController.navigate("lesson/new?studentId=$studentIdArg")
                 },
                 viewModel = viewModel
             )
@@ -76,7 +76,7 @@ fun TutorBillingApp() {
             route = "lesson/{lessonId}?studentId={studentId}",
             arguments = listOf(
                 navArgument("lessonId") {
-                    type = NavType.LongType
+                    type = NavType.StringType
                 },
                 navArgument("studentId") {
                     type = NavType.LongType
@@ -86,7 +86,7 @@ fun TutorBillingApp() {
         ) { backStackEntry ->
             val viewModel: LessonViewModel = hiltViewModel()
 
-            val lessonId = backStackEntry.arguments?.getLong("lessonId") ?: 0L
+            val lessonId = backStackEntry.arguments?.getString("lessonId") ?: "new"
             val studentId = backStackEntry.arguments?.getLong("studentId") ?: 0L
 
             LessonScreen(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -30,7 +30,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun LessonScreen(
     studentId: Long?,
-    lessonId: Long,
+    lessonId: String,
     onNavigateBack: () -> Unit,
     viewModel: LessonViewModel = hiltViewModel()
 ) {
@@ -41,7 +41,7 @@ fun LessonScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = if (lessonId == 0L) "Add Lesson" else "Edit Lesson"
+                        text = if (lessonId == "new") "Add Lesson" else "Edit Lesson"
                     )
                 },
                 navigationIcon = {
@@ -51,7 +51,7 @@ fun LessonScreen(
                 },
                 actions = {
                     var showDelete by remember { mutableStateOf(false) }
-                    if (lessonId != 0L) {
+                    if (lessonId != "new") {
                         IconButton(onClick = { showDelete = true }) {
                             Icon(Icons.Default.Delete, contentDescription = "Delete")
                         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -28,14 +28,14 @@ class LessonViewModel @Inject constructor(
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
     private val studentId: Long? = savedStateHandle.get<Long>("studentId")
-    private val lessonId: Long? = savedStateHandle.get<Long>("lessonId")
+    private val lessonId: String? = savedStateHandle.get<String>("lessonId")
 
     private val _uiState = MutableStateFlow(LessonUiState())
     val uiState: StateFlow<LessonUiState> = _uiState.asStateFlow()
 
     init {
         loadStudentInfo()
-        if (lessonId != null && lessonId != 0L) {
+        if (lessonId != null && lessonId != "new") {
             loadLesson()
         } else {
             // Set default values for new lesson
@@ -73,7 +73,7 @@ class LessonViewModel @Inject constructor(
 
     private fun loadLesson() {
         viewModelScope.launch(Dispatchers.IO) {
-            lessonId?.takeIf { it != 0L }?.let { id ->
+            lessonId?.takeIf { it != "new" }?.toLongOrNull()?.let { id ->
                 lessonDao.getLessonById(id).collect { lesson ->
                     lesson?.let { l ->
                         _uiState.update { state ->
@@ -162,7 +162,7 @@ class LessonViewModel @Inject constructor(
 
             val sId = state.selectedStudentId
             sId?.let {
-                if (lessonId == null || lessonId == 0L) {
+                if (lessonId == null || lessonId == "new") {
                     val lesson = Lesson(
                         studentId = it,
                         date = LocalDate.parse(state.date, dateFormatter).toString(),
@@ -173,7 +173,7 @@ class LessonViewModel @Inject constructor(
                     )
                     lessonDao.insert(lesson)
                 } else {
-                    lessonId?.let { lId ->
+                    lessonId?.toLongOrNull()?.let { lId ->
                         val lesson = Lesson(
                             id = lId,
                             studentId = it,
@@ -194,7 +194,7 @@ class LessonViewModel @Inject constructor(
 
     fun deleteLesson(onDeleted: () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
-            lessonId?.takeIf { it != 0L }?.let { id ->
+            lessonId?.takeIf { it != "new" }?.toLongOrNull()?.let { id ->
                 lessonDao.deleteById(id)
                 withContext(Dispatchers.Main) {
                     onDeleted()


### PR DESCRIPTION
## Summary
- use `"new"` as the marker for new Lesson routes
- update LessonScreen to accept lessonId as a string
- treat "new" as the default value in LessonViewModel

## Testing
- `./gradlew test --no-daemon` *(fails: Error occurred in KSP)*
- `./gradlew assembleDebug` *(fails: ModuleProcessingStep was unable to process)*

------
https://chatgpt.com/codex/tasks/task_e_684966d7f3d48330b352b71b30fef724