### PR TITLE
Add migration 5 to 6

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/Migrations.kt
@@ -68,6 +68,33 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("""
+            CREATE TABLE lessons_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                studentId INTEGER NOT NULL,
+                date TEXT NOT NULL,
+                startTime TEXT NOT NULL,
+                durationMinutes INTEGER NOT NULL,
+                notes TEXT,
+                isPaid INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(studentId) REFERENCES students(id) ON DELETE CASCADE
+            )
+        """.trimIndent())
+        db.execSQL("""
+            INSERT INTO lessons_new (id, studentId, date, startTime,
+                durationMinutes, notes, isPaid)
+            SELECT id, studentId, date, startTime,
+                durationMinutes, notes, isPaid FROM lessons
+        """.trimIndent())
+        db.execSQL("DROP TABLE lessons")
+        db.execSQL("ALTER TABLE lessons_new RENAME TO lessons")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_lessons_date ON lessons(date)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_lessons_studentId ON lessons(studentId)")
+    }
+}
+
 // Destructive migration fallback - use only as last resort
 val MIGRATION_FALLBACK = object : Migration(1, 5) {
     override fun migrate(db: SupportSQLiteDatabase) {


### PR DESCRIPTION
## Summary
- create MIGRATION_5_6 to rebuild lessons table, copy data and add indexes

## Testing
- `./gradlew test` *(fails: Android SDK install attempted)*

------
https://chatgpt.com/codex/tasks/task_e_68498117668083309befd1ec1f752e70