### PR TITLE
Fix database module constant reference

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/di/DatabaseModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.components.SingletonComponent
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
 import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.database.DatabaseConstants
 import gr.tsambala.tutorbilling.data.database.MIGRATION_1_2
 import gr.tsambala.tutorbilling.data.database.MIGRATION_2_3
 import gr.tsambala.tutorbilling.data.database.MIGRATION_3_4
@@ -30,7 +31,7 @@ object DatabaseModule {
         return Room.databaseBuilder(
             context,
             TutorBillingDatabase::class.java,
-            "tutor_billing_database"
+            DatabaseConstants.DATABASE_NAME
         )
             .addMigrations(
                 MIGRATION_1_2,


### PR DESCRIPTION
## Summary
- import `DatabaseConstants` in `DatabaseModule`
- use `DatabaseConstants.DATABASE_NAME` when building `TutorBillingDatabase`

## Testing
- `./gradlew test` *(fails: unresolved references)*

------
https://chatgpt.com/codex/tasks/task_e_684986f978388330b2091cf309ce328a