### PR TITLE
Fix compile issues with missing extensions

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -30,6 +30,7 @@ import androidx.core.net.toFile
 import gr.tsambala.tutorbilling.R
 import gr.tsambala.tutorbilling.data.database.LessonWithStudent
 import gr.tsambala.tutorbilling.ui.components.ClickableReadOnlyField
+import gr.tsambala.tutorbilling.utils.getFullName
 import java.io.File
 import java.io.FileOutputStream
 import java.time.LocalDate

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.material3.TimePicker
 import gr.tsambala.tutorbilling.ui.components.ClickableReadOnlyField
+import gr.tsambala.tutorbilling.utils.getFullName
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -280,7 +281,7 @@ fun LessonScreen(
                 Button(
                     onClick = {
                         viewModel.saveLesson()
-                        if (lessonId == 0L) {
+                        if (lessonId == "new") {
                             onNavigateBack()
                         }
                     },

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import gr.tsambala.tutorbilling.utils.getFullName
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -1,6 +1,8 @@
 // AppUtils.kt - Fixed currency formatting
 package gr.tsambala.tutorbilling.utils
 
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -26,6 +28,23 @@ fun formatAsCurrency(amount: Double): String {
  */
 fun formatAsEuro(amount: Double): String {
     return "€ %.2f".format(Locale.US, amount)
+}
+
+/**
+ * Extension version of [formatAsCurrency] used across the UI.
+ *
+ * @param symbol Currency symbol to use (defaults to "€")
+ * @param decimals Number of decimal places allowed (clamped to 0..2)
+ */
+fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
+    val safeDecimals = decimals.coerceIn(0, 2)
+    val symbols = DecimalFormatSymbols().apply { currencySymbol = symbol }
+    val pattern = "#,##0.${"0".repeat(safeDecimals)}"
+    val formatter = DecimalFormat(pattern, symbols).apply {
+        minimumFractionDigits = safeDecimals
+        maximumFractionDigits = safeDecimals
+    }
+    return formatter.format(this)
 }
 
 /**

--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/StudentExtensions.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/StudentExtensions.kt
@@ -1,0 +1,13 @@
+package gr.tsambala.tutorbilling.utils
+
+import gr.tsambala.tutorbilling.data.model.Student
+
+/**
+ * Returns the student's full name.
+ *
+ * The current [Student] model only stores a single `name` field, so this
+ * simply returns that value. Having this extension keeps compatibility with
+ * older code that expected a `getFullName()` helper.
+ */
+fun Student.getFullName(): String = this.name
+


### PR DESCRIPTION
## Summary
- add Student `getFullName()` extension
- reintroduce currency formatting extension for Double
- fix lesson save logic comparing String id
- import new extension in UI layers

## Testing
- `./gradlew testDebugUnitTest` *(fails: MigrationsTest and AppUtilsTest)*

------
https://chatgpt.com/codex/tasks/task_e_6849921be12c8330860f0d2ed06da164