### PR TITLE
Enable auto migrations

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/AutoMigrations.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/AutoMigrations.kt
@@ -1,0 +1,38 @@
+package gr.tsambala.tutorbilling.data.database
+
+import androidx.room.migration.AutoMigrationSpec
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Custom auto-migration from version 5 to 6.
+ * Handles recreating the lessons table to enforce
+ * foreign key constraints and string columns for date and time.
+ */
+class AutoMigration5To6 : AutoMigrationSpec {
+    override fun onPostMigrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE lessons_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                studentId INTEGER NOT NULL,
+                date TEXT NOT NULL,
+                startTime TEXT NOT NULL,
+                durationMinutes INTEGER NOT NULL,
+                notes TEXT,
+                isPaid INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY(studentId) REFERENCES students(id) ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO lessons_new (id, studentId, date, startTime, durationMinutes, notes, isPaid)
+            SELECT id, studentId, date, startTime, durationMinutes, notes, isPaid FROM lessons
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE lessons")
+        db.execSQL("ALTER TABLE lessons_new RENAME TO lessons")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_lessons_date ON lessons(date)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_lessons_studentId ON lessons(studentId)")
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -2,6 +2,7 @@
 package gr.tsambala.tutorbilling.data.database
 
 import android.content.Context
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -14,7 +15,15 @@ import gr.tsambala.tutorbilling.data.model.Student
 @Database(
     entities = [Student::class, Lesson::class],
     version = 7, // Current version
-    exportSchema = true
+    exportSchema = true,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2),
+        AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 4, to = 5),
+        AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7)
+    ]
 )
 abstract class TutorBillingDatabase : RoomDatabase() {
     abstract fun studentDao(): StudentDao
@@ -31,14 +40,6 @@ abstract class TutorBillingDatabase : RoomDatabase() {
                     TutorBillingDatabase::class.java,
                     DatabaseConstants.DATABASE_NAME
                 )
-                    // Add all migrations
-                    .addMigrations(
-                        MIGRATION_1_2,
-                        MIGRATION_2_3,
-                        MIGRATION_3_4,
-                        MIGRATION_4_5,
-                        MIGRATION_5_6
-                    )
                     // Fallback to destructive migration only in debug builds
                     .apply {
                         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import gr.tsambala.tutorbilling.data.database.AutoMigration5To6
 import gr.tsambala.tutorbilling.BuildConfig
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
@@ -21,7 +22,7 @@ import gr.tsambala.tutorbilling.data.model.Student
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
-        AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
         AutoMigration(from = 6, to = 7)
     ]
 )


### PR DESCRIPTION
## Summary
- enable Room auto migrations instead of manual list

## Testing
- `bash setup-android-sdk.sh`
- `./gradlew assembleDebug` *(fails: Starting a Gradle Daemon, 2 busy Daemons could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff42c6388330bfa8b2ee2f57dca4