### PR TITLE
Fix BuildConfig reference

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,8 @@ android {
     }
 
     buildFeatures {
+        // Explicitly generate BuildConfig to access BuildConfig.DEBUG
+        buildConfig true
         compose true
     }
 


### PR DESCRIPTION
## Summary
- enable generation of BuildConfig so the database module can reference `BuildConfig.DEBUG`

## Testing
- `./gradlew assembleDebug -x lint`
- `./gradlew test -x lint` *(fails: MigrationsTest and AppUtilsTest)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe4b00e88330af74d7f6d6e940c3