### PR TITLE
Clarify Room migration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ Use the Gradle wrapper to build and test the app:
 
 - **app** – main Compose application module containing UI, Hilt dependency injection and Room database code.
 
+## Database migrations
+
+Room is configured with `autoMigrations` for database version upgrades. The
+generated schema files are stored under `app/schemas` via the
+`room.schemaLocation` Gradle argument. Since auto-migration handles the schema
+changes, the project does not keep SQL scripts under
+`app/src/main/assets/migrations`.
+


### PR DESCRIPTION
## Summary
- document that the project uses Room autoMigrations
- note that schema files live in `app/schemas` and no SQL scripts are under `app/src/main/assets/migrations`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3477e3248330940585d082a009ad