### PR TITLE
fix(ui): correct currency format and state usage

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/students/StudentsScreen.kt
@@ -67,7 +67,7 @@ fun StudentsScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedTextField(
-                        value = viewModel.uiState.value.searchQuery,
+                        value = uiState.searchQuery,
                         onValueChange = viewModel::updateSearchQuery,
                         modifier = Modifier.weight(1f),
                         label = { Text("Search") }

--- a/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/utils/AppUtils.kt
@@ -26,7 +26,7 @@ fun Double.formatAsCurrency(symbol: String = "€", decimals: Int = 2): String {
         minimumFractionDigits = safeDecimals
         maximumFractionDigits = safeDecimals
     }
-    return formatter.format(this)
+    return "$symbol${formatter.format(this)}"
 }
 
 fun formatDuration(minutes: Int): String {


### PR DESCRIPTION
- WHAT changed
  - prefix currency symbol in `Double.formatAsCurrency`
  - use collected `uiState` for search field
- WHY it matters
  - fixes failing tests and lint error
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_684c168b159c8330af0c6972a2aaba2a