### PR TITLE
feat(student): extend student fields and add classes

### DIFF
--- a/app/schemas/gr.tsambala.tutorbilling.data.database.TutorBillingDatabase/8.json
+++ b/app/schemas/gr.tsambala.tutorbilling.data.database.TutorBillingDatabase/8.json
@@ -1,0 +1,170 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "d3fd15b847ca34913291af1928ae0380",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT, `rateType` TEXT NOT NULL DEFAULT 'hourly', `rate` REAL NOT NULL, `className` TEXT NOT NULL DEFAULT '', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `studentId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd3fd15b847ca34913291af1928ae0380')"
+    ]
+  }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
@@ -55,7 +55,12 @@ interface LessonDao {
                lessons.isPaid AS lesson_isPaid,
                students.id AS student_id,
                students.name AS student_name,
+               students.surname AS student_surname,
+               students.parentMobile AS student_parentMobile,
+               students.parentEmail AS student_parentEmail,
+               students.rateType AS student_rateType,
                students.rate AS student_rate,
+               students.className AS student_className,
                students.isActive AS student_isActive
         FROM lessons JOIN students ON lessons.studentId = students.id
         ORDER BY lessons.date DESC, lessons.startTime DESC
@@ -75,7 +80,12 @@ interface LessonDao {
                lessons.isPaid AS lesson_isPaid,
                students.id AS student_id,
                students.name AS student_name,
+               students.surname AS student_surname,
+               students.parentMobile AS student_parentMobile,
+               students.parentEmail AS student_parentEmail,
+               students.rateType AS student_rateType,
                students.rate AS student_rate,
+               students.className AS student_className,
                students.isActive AS student_isActive
         FROM lessons JOIN students ON lessons.studentId = students.id
         WHERE lessons.studentId = :studentId
@@ -96,7 +106,12 @@ interface LessonDao {
                lessons.isPaid AS lesson_isPaid,
                students.id AS student_id,
                students.name AS student_name,
+               students.surname AS student_surname,
+               students.parentMobile AS student_parentMobile,
+               students.parentEmail AS student_parentEmail,
+               students.rateType AS student_rateType,
                students.rate AS student_rate,
+               students.className AS student_className,
                students.isActive AS student_isActive
         FROM lessons JOIN students ON lessons.studentId = students.id
         WHERE lessons.date BETWEEN :startDate AND :endDate
@@ -117,7 +132,12 @@ interface LessonDao {
                lessons.isPaid AS lesson_isPaid,
                students.id AS student_id,
                students.name AS student_name,
+               students.surname AS student_surname,
+               students.parentMobile AS student_parentMobile,
+               students.parentEmail AS student_parentEmail,
+               students.rateType AS student_rateType,
                students.rate AS student_rate,
+               students.className AS student_className,
                students.isActive AS student_isActive
         FROM lessons JOIN students ON lessons.studentId = students.id
         WHERE lessons.studentId = :studentId AND lessons.date BETWEEN :startDate AND :endDate

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -14,7 +14,7 @@ import gr.tsambala.tutorbilling.data.model.Student
 
 @Database(
     entities = [Student::class, Lesson::class],
-    version = 7, // Current version
+    version = 8, // Current version
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -22,7 +22,8 @@ import gr.tsambala.tutorbilling.data.model.Student
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
         AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
-        AutoMigration(from = 6, to = 7)
+        AutoMigration(from = 6, to = 7),
+        AutoMigration(from = 7, to = 8)
     ]
 )
 abstract class TutorBillingDatabase : RoomDatabase() {

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/Student.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/Student.kt
@@ -10,7 +10,16 @@ data class Student(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
     val name: String,
-    val rate: Double, // Hourly rate in euros
+    @ColumnInfo(defaultValue = "")
+    val surname: String,
+    @ColumnInfo(defaultValue = "")
+    val parentMobile: String,
+    val parentEmail: String? = null,
+    @ColumnInfo(defaultValue = RateTypes.HOURLY)
+    val rateType: String = RateTypes.HOURLY,
+    val rate: Double,
+    @ColumnInfo(defaultValue = "")
+    val className: String,
     @ColumnInfo(defaultValue = "1")
     val isActive: Boolean = true // Default to active
 )

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/model/StudentClasses.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/model/StudentClasses.kt
@@ -1,0 +1,18 @@
+package gr.tsambala.tutorbilling.data.model
+
+object StudentClasses {
+    val predefined = listOf(
+        "Junior A",
+        "Junior B",
+        "Junior A&B One-Year Course",
+        "Senior A",
+        "Senior B",
+        "Senior C",
+        "Senior D/B1",
+        "Pre-B2",
+        "B2",
+        "C1/Advanced",
+        "C2/Proficiency",
+        "Custom"
+    )
+}

--- a/app/src/test/java/gr/tsambala/tutorbilling/data/database/MigrationsTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/data/database/MigrationsTest.kt
@@ -26,9 +26,9 @@ class MigrationsTest {
     @Test
     fun migrateAllVersionsToLatest() {
         val context = ApplicationProvider.getApplicationContext<Context>()
-        for (version in 1..6) {
+        for (version in 1..7) {
             helper.createDatabase(TEST_DB, version).close()
-            helper.runMigrationsAndValidate(TEST_DB, 7, true)
+            helper.runMigrationsAndValidate(TEST_DB, 8, true)
             context.deleteDatabase(TEST_DB)
         }
     }


### PR DESCRIPTION
## Summary
- add student classes list
- extend Student entity with surname, parent contacts, rate type and class
- handle new fields in StudentEditForm and StudentViewModel
- update LessonDao to include new columns
- bump DB version to 8 and adjust migration tests

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: MavenArtifactFetcher SocketException)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_684c841999ac8330b7691f8b01dc65ad