### PR TITLE
feat(classes): group students by class

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesScreen.kt
@@ -52,22 +52,46 @@ fun ClassesScreen(
                 .fillMaxSize()
                 .padding(padding)
         ) {
-            uiState.studentsByClass.forEach { (className, students) ->
-                item {
-                    Text(
-                        text = className,
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(16.dp)
-                    )
-                    HorizontalDivider()
+            uiState.studentsByClass
+                .filterKeys { it != "Unassigned" }
+                .toSortedMap()
+                .forEach { (className, students) ->
+                    item {
+                        Text(
+                            text = className,
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                        HorizontalDivider()
+                    }
+                    items(students) { student ->
+                        Text(
+                            text = student.name,
+                            modifier = Modifier
+                                .padding(horizontal = 32.dp, vertical = 8.dp)
+                                .clickable { onStudentClick(student.id) }
+                        )
+                    }
                 }
-                items(students) { student ->
-                    Text(
-                        text = student.name,
-                        modifier = Modifier
-                            .padding(horizontal = 32.dp, vertical = 8.dp)
-                            .clickable { onStudentClick(student.id) }
-                    )
+
+            if (uiState.hasUnassigned) {
+                uiState.studentsByClass["Unassigned"]?.let { students ->
+                    item {
+                        Text(
+                            text = "Unassigned",
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                        HorizontalDivider()
+                    }
+                    items(students) { student ->
+                        Text(
+                            text = student.name,
+                            modifier = Modifier
+                                .padding(horizontal = 32.dp, vertical = 8.dp)
+                                .clickable { onStudentClick(student.id) }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/classes/ClassesViewModel.kt
@@ -22,8 +22,15 @@ class ClassesViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             studentDao.getAllActiveStudents().map { students ->
-                val grouped = mapOf("All" to students)
-                val hasUnassigned = false
+                val grouped = students.groupBy { student ->
+                    val name = student.className.trim()
+                    if (name.isBlank() || name.equals("unknown", ignoreCase = true)) {
+                        "Unassigned"
+                    } else {
+                        name
+                    }
+                }
+                val hasUnassigned = grouped.containsKey("Unassigned")
                 ClassesUiState(grouped, hasUnassigned)
             }.collect { state ->
                 _uiState.value = state


### PR DESCRIPTION
## Summary
- group students by class in ClassesViewModel
- show unassigned students separately in ClassesScreen

## Testing
- `./gradlew clean`
- `./gradlew assemble` *(fails: process killed or truncated)*
- `./gradlew test` *(fails: 2 tests failed)*
- `./gradlew lintDebug` *(fails or truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684c9be9f4c88330be669e145428b084