### PR TITLE
fix: improve form validation and lesson deletion

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -152,8 +152,14 @@ fun TutorBillingApp() {
             val viewModel: LessonViewModel = hiltViewModel()
 
             val lessonId = backStackEntry.arguments?.getString("lessonId") ?: "new"
-          
+
             val studentId = backStackEntry.arguments?.getLong("studentId") ?: 0L
+
+            LaunchedEffect(Unit) {
+                viewModel.setNavigationCallback {
+                    navController.popBackStack()
+                }
+            }
 
             LessonScreen(
                 studentId = studentId.takeIf { it != 0L },

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/components/ClickableReadOnlyField.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/components/ClickableReadOnlyField.kt
@@ -2,11 +2,12 @@ package gr.tsambala.tutorbilling.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
+import androidx.compose.foundation.interaction.MutableInteractionSource
 
 @Composable
 fun ClickableReadOnlyField(
@@ -16,19 +17,19 @@ fun ClickableReadOnlyField(
     singleLine: Boolean = true,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = {},
-            readOnly = true,
-            label = label,
-            singleLine = singleLine,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Box(
-            Modifier
-                .fillMaxSize()
-                .clickable(onClick = onClick)
-        )
-    }
+    val interaction = remember { MutableInteractionSource() }
+    OutlinedTextField(
+        value = value,
+        onValueChange = {},
+        readOnly = true,
+        label = label,
+        singleLine = singleLine,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onClick
+            )
+    )
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -105,7 +105,8 @@ class LessonViewModel @Inject constructor(
 
     fun updateDuration(duration: String) {
         val digits = duration.filter { it.isDigit() }
-        val sanitized = digits.toIntOrNull()?.takeIf { it > 0 }?.toString() ?: ""
+        val number = digits.toIntOrNull()?.coerceIn(0, 180) ?: 0
+        val sanitized = number.takeIf { it > 0 }?.toString() ?: ""
         _uiState.update { it.copy(durationMinutes = sanitized) }
     }
 
@@ -152,7 +153,7 @@ class LessonViewModel @Inject constructor(
             hasStudent && validDateTime
         } else {
             val duration = state.durationMinutes.toIntOrNull() ?: 0
-            hasStudent && validDateTime && duration >= 60
+            hasStudent && validDateTime && duration in 60..180
         }
     }
 
@@ -169,6 +170,7 @@ class LessonViewModel @Inject constructor(
             } else {
                 if (duration <= 0) duration = 60
                 if (duration < 60) duration = 60
+                if (duration > 180) duration = 180
                 _uiState.update { it.copy(durationMinutes = duration.toString()) }
             }
             if (!isFormValid()) return@launch

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import android.util.Patterns
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.tsambala.tutorbilling.data.model.RateTypes
@@ -384,7 +385,8 @@ private fun StudentEditForm(
     modifier: Modifier = Modifier
 ) {
     val nameError = uiState.name.isBlank()
-    val rateError = uiState.rate.toDoubleOrNull() == null
+    val rateValue = uiState.rate.toDoubleOrNull()
+    val rateError = rateValue == null || rateValue <= 0.0
 
     Column(
         modifier = modifier
@@ -415,22 +417,27 @@ private fun StudentEditForm(
             singleLine = true
         )
 
-        val mobileError = uiState.parentMobile.isBlank()
+        val mobileError =
+            uiState.parentMobile.length != 10 || uiState.parentMobile.any { !it.isDigit() }
         OutlinedTextField(
             value = uiState.parentMobile,
             onValueChange = viewModel::updateParentMobile,
             label = { Text("Parent's Mobile*") },
             isError = mobileError,
-            supportingText = { if (mobileError) Text("Required") },
+            supportingText = { if (mobileError) Text("10-digit number") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
 
+        val emailError = uiState.parentEmail.isNotBlank() &&
+            !Patterns.EMAIL_ADDRESS.matcher(uiState.parentEmail).matches()
         OutlinedTextField(
             value = uiState.parentEmail,
             onValueChange = viewModel::updateParentEmail,
             label = { Text("Parent's Email") },
+            isError = emailError,
+            supportingText = { if (emailError) Text("Invalid email") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
@@ -545,10 +552,13 @@ private fun StudentEditForm(
                 modifier = Modifier.weight(1f),
                 enabled = uiState.name.isNotBlank() &&
                     uiState.surname.isNotBlank() &&
-                    uiState.parentMobile.isNotBlank() &&
-                    uiState.rate.toDoubleOrNull() != null &&
+                    uiState.parentMobile.length == 10 &&
+                    uiState.parentMobile.all { it.isDigit() } &&
+                    rateValue != null && rateValue > 0 &&
                     uiState.selectedClass.isNotBlank() &&
-                    (uiState.selectedClass != "Custom" || uiState.customClass.isNotBlank())
+                    (uiState.selectedClass != "Custom" || uiState.customClass.isNotBlank()) &&
+                    (uiState.parentEmail.isBlank() ||
+                        Patterns.EMAIL_ADDRESS.matcher(uiState.parentEmail).matches())
             ) {
                 Text("Save")
             }


### PR DESCRIPTION
- WHAT changed
  - enforced positive rates and phone/email validation on student forms
  - limited lesson duration to maximum 180 minutes
  - fixed read-only field click handling for date/time pickers
  - ensured lesson delete navigates back
- WHY it matters
  - prevents invalid data entry and improves UX after deletion
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_684c9daa5a488330aff709a528057818