### PR TITLE
refactor(navigation): extract student routes

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -9,7 +9,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import gr.tsambala.tutorbilling.ui.home.HomeMenuScreen
-import gr.tsambala.tutorbilling.ui.students.StudentsScreen
 import gr.tsambala.tutorbilling.ui.classes.ClassesScreen
 import gr.tsambala.tutorbilling.ui.lessons.LessonsScreen
 import gr.tsambala.tutorbilling.ui.lesson.LessonScreen
@@ -18,8 +17,7 @@ import gr.tsambala.tutorbilling.ui.revenue.RevenueScreen
 import gr.tsambala.tutorbilling.ui.invoice.InvoiceScreen
 import gr.tsambala.tutorbilling.ui.invoice.PastInvoicesScreen
 import gr.tsambala.tutorbilling.ui.settings.SettingsScreen
-import gr.tsambala.tutorbilling.ui.student.StudentScreen
-import gr.tsambala.tutorbilling.ui.student.StudentViewModel
+import gr.tsambala.tutorbilling.navigation.studentGraph
 
 @Composable
 fun TutorBillingApp() {
@@ -42,18 +40,7 @@ fun TutorBillingApp() {
             )
         }
 
-        // Students list screen
-        composable(Screen.Students.route) {
-            StudentsScreen(
-                onNavigateToStudent = { id ->
-                    navController.navigate(Screen.Student.createRoute(id))
-                },
-                onAddStudent = {
-                    navController.navigate(Screen.Student.createRoute(0))
-                },
-                onBack = { navController.popBackStack() }
-            )
-        }
+        studentGraph(navController)
 
         // Classes list screen
         composable(Screen.Classes.route) {
@@ -101,40 +88,6 @@ fun TutorBillingApp() {
             SettingsScreen(onBack = { navController.popBackStack() })
         }
 
-        // Student Detail/Edit Screen
-        composable(
-            route = Screen.Student.route,
-            arguments = listOf(
-                navArgument("studentId") {
-                    type = NavType.LongType
-                }
-            )
-        ) { backStackEntry ->
-            val viewModel: StudentViewModel = hiltViewModel()
-
-            // Obtain the student id from the nav arguments
-            val studentIdArg = backStackEntry.arguments?.getLong("studentId") ?: 0L
-
-            // Set up navigation callback
-            LaunchedEffect(Unit) {
-                viewModel.setNavigationCallback {
-                    navController.popBackStack()
-                }
-            }
-
-            val studentId = studentIdArg.toString()
-            StudentScreen(
-                studentId = studentId,
-                onNavigateBack = { navController.popBackStack() },
-                onNavigateToLesson = { lessonId ->
-                    navController.navigate(Screen.Lesson.createRoute(lessonId.toString(), studentIdArg))
-                },
-                onAddLesson = {
-                    navController.navigate(Screen.Lesson.createRoute("new", studentIdArg))
-                },
-                viewModel = viewModel
-            )
-        }
 
         // Lesson Detail/Edit Screen
         composable(

--- a/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
@@ -1,0 +1,64 @@
+package gr.tsambala.tutorbilling.navigation
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import androidx.navigation.navigation
+import gr.tsambala.tutorbilling.Screen
+import gr.tsambala.tutorbilling.ui.student.StudentScreen
+import gr.tsambala.tutorbilling.ui.student.StudentViewModel
+import gr.tsambala.tutorbilling.ui.students.StudentsScreen
+
+fun NavGraphBuilder.studentGraph(navController: NavHostController) {
+    navigation(startDestination = Screen.Students.route, route = "student_graph") {
+        composable(Screen.Students.route) {
+            StudentsScreen(
+                onNavigateToStudent = { id ->
+                    navController.navigate(Screen.Student.createRoute(id))
+                },
+                onAddStudent = {
+                    navController.navigate(Screen.Student.createRoute(0))
+                },
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(
+            route = Screen.Student.route,
+            arguments = listOf(
+                navArgument("studentId") {
+                    type = NavType.LongType
+                }
+            )
+        ) { backStackEntry ->
+            val viewModel: StudentViewModel = hiltViewModel()
+
+            val studentIdArg = backStackEntry.arguments?.getLong("studentId") ?: 0L
+
+            LaunchedEffect(Unit) {
+                viewModel.setNavigationCallback {
+                    navController.popBackStack()
+                }
+            }
+
+            val studentId = studentIdArg.toString()
+            StudentScreen(
+                studentId = studentId,
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToLesson = { lessonId ->
+                    navController.navigate(
+                        Screen.Lesson.createRoute(lessonId.toString(), studentIdArg)
+                    )
+                },
+                onAddLesson = {
+                    navController.navigate(Screen.Lesson.createRoute("new", studentIdArg))
+                },
+                viewModel = viewModel
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move student related composables to a dedicated NavGraph
- call `studentGraph` from `TutorBillingApp`

## Testing
- `./gradlew clean assemble test lintDebug` *(fails: `Execution failed for task ':app:testReleaseUnitTest'`)*

------
https://chatgpt.com/codex/tasks/task_e_684c9db964f483309557a538d102752c