### PR TITLE
fix(invoice): finalize generation flow

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
@@ -51,11 +51,11 @@ fun NavGraphBuilder.studentGraph(navController: NavHostController) {
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToLesson = { lessonId ->
                     navController.navigate(
-                        Screen.Lesson.createRoute(lessonId.toString(), studentIdArg)
+                        Screen.Lesson.createRoute(lessonId, studentIdArg)
                     )
                 },
                 onAddLesson = {
-                    navController.navigate(Screen.Lesson.createRoute("new", studentIdArg))
+                    navController.navigate(Screen.Lesson.createRoute(0, studentIdArg))
                 },
                 viewModel = viewModel
             )


### PR DESCRIPTION
- updated StudentNavGraph to use numeric lesson ids
- added confirmation dialog and marking lessons paid when creating invoice
- renamed bottom bar buttons and improved invoice generation UX

How to test:
- `./gradlew assemble`
- `./gradlew lintDebug`
- `./gradlew test` *(fails: MavenArtifactFetcher socket exception)*

------
https://chatgpt.com/codex/tasks/task_e_684ca744430883309fa08ff07715c7cd