### PR TITLE
fix(student-nav): correct route parameter types

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/navigation/StudentNavGraph.kt
@@ -51,11 +51,11 @@ fun NavGraphBuilder.studentGraph(navController: NavHostController) {
                 onNavigateBack = { navController.popBackStack() },
                 onNavigateToLesson = { lessonId ->
                     navController.navigate(
-                        Screen.Lesson.createRoute(lessonId.toString(), studentIdArg)
+                        Screen.Lesson.createRoute(lessonId, studentIdArg)
                     )
                 },
                 onAddLesson = {
-                    navController.navigate(Screen.Lesson.createRoute("new", studentIdArg))
+                    navController.navigate(Screen.Lesson.createRoute(0L, studentIdArg))
                 },
                 viewModel = viewModel
             )


### PR DESCRIPTION
- fixed argument types in `StudentNavGraph` when creating lesson routes
- attempted `./gradlew assemble`, `./gradlew test`, and `./gradlew lintDebug` but they didn't finish within the environment


------
https://chatgpt.com/codex/tasks/task_e_684cabdc964483309c02ac1c2e82e80c