### PR TITLE
feat(lessons): add FAB navigation

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -60,6 +60,9 @@ fun TutorBillingApp() {
                     navController.navigate(
                         Screen.Lesson.createRoute(lessonId, studentId)
                     )
+                },
+                onAddLesson = {
+                    navController.navigate(Screen.Lesson.createRoute(0))
                 }
             )
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
@@ -27,6 +28,7 @@ import java.time.format.DateTimeFormatter
 fun LessonsScreen(
     onBack: () -> Unit,
     onLessonClick: (Long, Long) -> Unit,
+    onAddLesson: () -> Unit,
     viewModel: LessonsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -45,6 +47,11 @@ fun LessonsScreen(
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddLesson) {
+                Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add_lesson))
+            }
         }
     ) { padding ->
         if (uiState.lessons.isEmpty()) {


### PR DESCRIPTION
- WHAT changed
  - Add `onAddLesson` callback to `LessonsScreen` and show FAB using this handler
  - Update navigation so Lessons screen opens lesson editor on FAB tap
- WHY it matters
  - Enables quick creation of new lessons from the list
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_684d496ea3348330832740d39f634a47