### PR TITLE
feat(revenue): track and display student debts

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/NavigationRoutes.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/NavigationRoutes.kt
@@ -13,7 +13,9 @@ sealed class Screen(val route: String) {
     }
     object Classes : Screen("classes")
     object Revenue : Screen("revenue")
-    object Invoice : Screen("invoice")
+    object Invoice : Screen("invoice?studentId={studentId}") {
+        fun createRoute(studentId: Long = 0L) = "invoice?studentId=$studentId"
+    }
     object PastInvoices : Screen("pastInvoices")
     object Settings : Screen("settings")
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -16,6 +16,7 @@ import gr.tsambala.tutorbilling.ui.lesson.LessonViewModel
 import gr.tsambala.tutorbilling.ui.revenue.RevenueScreen
 import gr.tsambala.tutorbilling.ui.invoice.InvoiceScreen
 import gr.tsambala.tutorbilling.ui.invoice.PastInvoicesScreen
+import gr.tsambala.tutorbilling.ui.invoice.InvoiceViewModel
 import gr.tsambala.tutorbilling.ui.settings.SettingsScreen
 import gr.tsambala.tutorbilling.navigation.studentGraph
 
@@ -68,14 +69,25 @@ fun TutorBillingApp() {
         composable(Screen.Revenue.route) {
             RevenueScreen(
                 onBack = { navController.popBackStack() },
-                onInvoice = { navController.navigate(Screen.Invoice.route) },
+                onInvoice = { id -> navController.navigate(Screen.Invoice.createRoute(id ?: 0L)) },
                 onPastInvoices = { navController.navigate(Screen.PastInvoices.route) }
             )
         }
 
         // Invoice screen
-        composable(Screen.Invoice.route) {
-            InvoiceScreen(onBack = { navController.popBackStack() })
+        composable(
+            route = Screen.Invoice.route,
+            arguments = listOf(
+                navArgument("studentId") {
+                    type = NavType.LongType
+                    defaultValue = 0L
+                }
+            )
+        ) { backStackEntry ->
+            val viewModel: InvoiceViewModel = hiltViewModel()
+            val id = backStackEntry.arguments?.getLong("studentId") ?: 0L
+            LaunchedEffect(id) { if (id != 0L) viewModel.selectStudent(id) }
+            InvoiceScreen(onBack = { navController.popBackStack() }, viewModel = viewModel)
         }
 
         // Past invoices screen

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueScreen.kt
@@ -1,6 +1,8 @@
 package gr.tsambala.tutorbilling.ui.revenue
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -8,17 +10,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import android.content.Intent
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.tsambala.tutorbilling.ui.settings.SettingsViewModel
 import gr.tsambala.tutorbilling.utils.formatAsCurrency
+import gr.tsambala.tutorbilling.ui.revenue.StudentDebt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RevenueScreen(
     onBack: () -> Unit,
-    onInvoice: () -> Unit,
+    onInvoice: (Long?) -> Unit,
     onPastInvoices: () -> Unit,
     viewModel: RevenueViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel()
@@ -112,13 +117,29 @@ fun RevenueScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Button(
-                    onClick = onInvoice,
+                    onClick = { onInvoice(null) },
                     modifier = Modifier.weight(1f)
                 ) { Text("New Invoice") }
                 OutlinedButton(
                     onClick = onPastInvoices,
                     modifier = Modifier.weight(1f)
                 ) { Text("Past Invoices") }
+            }
+
+            if (uiState.debts.isNotEmpty()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.debts, key = { it.student.id }) { debt ->
+                        StudentDebtRow(
+                            debt = debt,
+                            onInvoice = { onInvoice(debt.student.id) },
+                            onMarkPaid = { viewModel.markLessonsPaid(debt.student.id) },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
             }
         }
     }
@@ -135,6 +156,48 @@ private fun MetricTile(
         Column(Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             Text(label, style = MaterialTheme.typography.labelSmall)
             Text(value, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+@Composable
+private fun StudentDebtRow(
+    debt: StudentDebt,
+    onInvoice: () -> Unit,
+    onMarkPaid: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    Card(modifier = modifier) {
+        Column(Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(debt.student.name, style = MaterialTheme.typography.titleMedium)
+                Text(debt.amount.formatAsCurrency())
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(onClick = onInvoice, modifier = Modifier.weight(1f)) { Text("Invoice") }
+                OutlinedButton(onClick = onMarkPaid, modifier = Modifier.weight(1f)) { Text("Mark Paid") }
+                OutlinedButton(
+                    onClick = {
+                        val share = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(
+                                Intent.EXTRA_TEXT,
+                                "Please pay your outstanding balance of " + debt.amount.formatAsCurrency()
+                            )
+                        }
+                        context.startActivity(Intent.createChooser(share, null))
+                    },
+                    modifier = Modifier.weight(1f)
+                ) { Text("Reminder") }
+            }
         }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/StudentDebt.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/StudentDebt.kt
@@ -1,0 +1,10 @@
+package gr.tsambala.tutorbilling.ui.revenue
+
+import androidx.compose.runtime.Stable
+import gr.tsambala.tutorbilling.data.model.Student
+
+@Stable
+data class StudentDebt(
+    val student: Student,
+    val amount: Double
+)


### PR DESCRIPTION
- compute unpaid debt per student and expose in `RevenueUiState`
- new `StudentDebt` model annotated with `@Stable`
- added `markLessonsPaid` helper
- show debts in `RevenueScreen` with invoice, paid and reminder actions
- allow navigating to Invoice screen with pre-selected student

Checklist:
- [ ] Unit tests passing
- [ ] Lint shows 0 new warnings
- [ ] No TODOs or commented-out code left
- [ ] `./gradlew assemble` succeeds on CI

------
https://chatgpt.com/codex/tasks/task_e_684d4b13f8c88330a5af2e3fc00d5d3e