### PR TITLE
feat(ci): add workflow for build and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Android SDK
+        run: |
+          bash setup-android-sdk.sh
+          source $HOME/.profile
+      - name: Build, Test and Lint
+        run: |
+          ./gradlew clean assemble test lintDebug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix launcher icon references in the AndroidManifest.
+- Add CI workflow to run clean, assemble, test and lint on every push.
 
 ## [0.14] - 2025-06-15
 ### Added


### PR DESCRIPTION
- WHAT changed
  - Added `.github/workflows/ci.yml` to automate clean, assemble, test and lint on push and PR events
  - Updated CHANGELOG entry
- WHY it matters
  - Ensures each push runs the full build, tests and lint checks in CI
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_684ea634bf9083309fcd9b09e89862a1