### PR TITLE
feat(build): configure release signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ out/ # Default output directory for IntelliJ
 *.dex
 captures/
 
+release.jks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.
 - Update Android Gradle Plugin and wrapper to 8.1.0.
+- Enable Play App Signing release builds with keystore placeholders.
 
 ## [0.14] - 2025-06-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ Use the Gradle wrapper to build, lint and test the app:
 ./gradlew lintDebug
 ```
 
+### Signing release builds
+
+Release variants require a keystore so the generated APK/AAB can be uploaded to
+Google Play with Play App Signing. Provide the keystore path and credentials via
+Gradle properties or environment variables before running `assembleRelease`:
+
+```bash
+export RELEASE_STORE_FILE=/path/to/keystore.jks
+export RELEASE_STORE_PASSWORD=keystorePassword
+export RELEASE_KEY_ALIAS=releaseKey
+export RELEASE_KEY_PASSWORD=keyPassword
+```
+
+Gradle will pick up these values when assembling the `release` variant.
+
 ## Modules overview
 
 - **app** – main Compose application module containing UI, Hilt dependency injection and Room database code.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,18 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            storeFile file(findProperty('RELEASE_STORE_FILE') ?: System.getenv('RELEASE_STORE_FILE') ?: '')
+            storePassword findProperty('RELEASE_STORE_PASSWORD') ?: System.getenv('RELEASE_STORE_PASSWORD')
+            keyAlias findProperty('RELEASE_KEY_ALIAS') ?: System.getenv('RELEASE_KEY_ALIAS')
+            keyPassword findProperty('RELEASE_KEY_PASSWORD') ?: System.getenv('RELEASE_KEY_PASSWORD')
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/gradlew
+++ b/gradlew
@@ -198,7 +198,7 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-Collect all arguments for the java command;
+# Collect all arguments for the java command;
 #   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
 #     shell script including quotes and variable substitutions, so put them in
 #     double quotes to make sure that they get re-expanded; and


### PR DESCRIPTION
- add release signing configuration with keystore placeholders
- document keystore environment variables
- ignore example keystore file

## Testing
- `./gradlew clean` *(fails: Unsupported class file major version 65)*
- `./gradlew assemble` *(not run: prior step failed)*
- `./gradlew test` *(not run)*
- `./gradlew lintDebug` *(not run)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684ebfa251c08330ac3be471cc2f23fd