### PR TITLE
feat(auth): add optional Google sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.
 - Enable Play App Signing release builds with keystore placeholders.
 - Make release signingConfig conditional on keystore properties.
+- Optional Google Sign-In with account persisted in DataStore.
 
 ## [0.14] - 2025-06-15
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,6 +112,9 @@ android {
     // DataStore for app settings
     implementation "androidx.datastore:datastore-preferences:1.1.7"
 
+    // Google Sign-In
+    implementation "com.google.android.gms:play-services-auth:21.2.0"
+
     // Hilt - Updated to compatible version
     implementation "com.google.dagger:hilt-android:2.54"
     ksp "com.google.dagger:hilt-compiler:2.54"

--- a/app/src/main/java/gr/tsambala/tutorbilling/MainActivity.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/MainActivity.kt
@@ -3,6 +3,9 @@ package gr.tsambala.tutorbilling
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -15,8 +18,11 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private lateinit var signInClient: GoogleSignInClient
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        signInClient = GoogleSignIn.getClient(this, GoogleSignInOptions.DEFAULT_SIGN_IN)
         setContent {
             val viewModel: SettingsViewModel = hiltViewModel()
             val settings = viewModel.settings.collectAsStateWithLifecycle().value
@@ -25,7 +31,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    TutorBillingApp()
+                    TutorBillingApp(signInClient)
                 }
             }
         }

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -2,6 +2,7 @@ package gr.tsambala.tutorbilling
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -21,7 +22,7 @@ import gr.tsambala.tutorbilling.ui.settings.SettingsScreen
 import gr.tsambala.tutorbilling.navigation.studentGraph
 
 @Composable
-fun TutorBillingApp() {
+fun TutorBillingApp(signInClient: GoogleSignInClient) {
     val navController = rememberNavController()
 
     NavHost(
@@ -104,7 +105,10 @@ fun TutorBillingApp() {
 
         // Settings screen
         composable(Screen.Settings.route) {
-            SettingsScreen(onBack = { navController.popBackStack() })
+            SettingsScreen(
+                onBack = { navController.popBackStack() },
+                signInClient = signInClient
+            )
         }
 
         // Lesson Detail/Edit Screen

--- a/app/src/main/java/gr/tsambala/tutorbilling/data/auth/AccountRepository.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/data/auth/AccountRepository.kt
@@ -1,0 +1,46 @@
+package gr.tsambala.tutorbilling.data.auth
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.accountDataStore by preferencesDataStore("account")
+
+data class GoogleAccount(
+    val email: String,
+    val displayName: String
+)
+
+@Singleton
+class AccountRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private object Keys {
+        val EMAIL = stringPreferencesKey("email")
+        val DISPLAY_NAME = stringPreferencesKey("display_name")
+    }
+
+    val account: Flow<GoogleAccount?> = context.accountDataStore.data.map { prefs ->
+        val email = prefs[Keys.EMAIL]
+        val name = prefs[Keys.DISPLAY_NAME] ?: ""
+        if (email == null) null else GoogleAccount(email, name)
+    }
+
+    suspend fun saveAccount(account: GoogleSignInAccount) {
+        context.accountDataStore.edit {
+            it[Keys.EMAIL] = account.email ?: ""
+            it[Keys.DISPLAY_NAME] = account.displayName ?: ""
+        }
+    }
+
+    suspend fun clearAccount() {
+        context.accountDataStore.edit { it.clear() }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
@@ -11,14 +11,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.Alignment
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,
+    signInClient: GoogleSignInClient,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
+    val account by viewModel.account.collectAsStateWithLifecycle()
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+        if (task.isSuccessful) {
+            task.result?.let { viewModel.saveGoogleAccount(it) }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -61,6 +73,16 @@ fun SettingsScreen(
                     checked = settings.darkTheme,
                     onCheckedChange = viewModel::updateDarkTheme
                 )
+            }
+            if (account == null) {
+                Button(onClick = { launcher.launch(signInClient.signInIntent) }) {
+                    Text("Sign in with Google")
+                }
+            } else {
+                Text("Signed in as ${'$'}{account.displayName}")
+                Button(onClick = viewModel::signOut) {
+                    Text("Sign out")
+                }
             }
         }
     }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsViewModel.kt
@@ -3,21 +3,31 @@ package gr.tsambala.tutorbilling.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import gr.tsambala.tutorbilling.data.auth.AccountRepository
+import gr.tsambala.tutorbilling.data.auth.GoogleAccount
 import gr.tsambala.tutorbilling.data.settings.AppSettings
 import gr.tsambala.tutorbilling.data.settings.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val repository: SettingsRepository
+    private val repository: SettingsRepository,
+    private val accountRepository: AccountRepository
 ) : ViewModel() {
     private val _settings = MutableStateFlow(AppSettings())
     val settings: StateFlow<AppSettings> = _settings.asStateFlow()
+    val account: StateFlow<GoogleAccount?> = accountRepository.account.stateIn(
+        scope = viewModelScope,
+        started = kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000),
+        initialValue = null
+    )
 
     init {
         viewModelScope.launch {
@@ -35,5 +45,13 @@ class SettingsViewModel @Inject constructor(
 
     fun updateDarkTheme(enabled: Boolean) {
         viewModelScope.launch { repository.setDarkTheme(enabled) }
+    }
+
+    fun saveGoogleAccount(account: GoogleSignInAccount) {
+        viewModelScope.launch { accountRepository.saveAccount(account) }
+    }
+
+    fun signOut() {
+        viewModelScope.launch { accountRepository.clearAccount() }
     }
 }


### PR DESCRIPTION
- add play-services-auth dependency
- persist signed-in account via new AccountRepository
- integrate GoogleSignInClient with Settings screen
- expose sign-in client from MainActivity

`./gradlew lintDebug` succeeded, but unit tests failed locally

------
https://chatgpt.com/codex/tasks/task_e_684fe38dc0448330bc6f02a3c3457c54