### PR TITLE
feat(modules): add data & domain modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add rebuild walkthrough in `rebuild.md` describing detailed steps.
+- Add domain and data modules for clean architecture foundation.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.
 - Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,8 @@ android {
 }
 
     dependencies {
+        implementation project(':domain')
+        implementation project(':data')
         // Core Android
         implementation 'androidx.core:core-ktx:1.16.0'
         implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.1'

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'gr.tsambala.tutorbilling.data'
+    compileSdk 35
+
+    defaultConfig {
+        minSdk 26
+        targetSdk 35
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation project(':domain')
+}

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/Placeholder.java
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/Placeholder.java
@@ -1,0 +1,3 @@
+package gr.tsambala.tutorbilling.data;
+
+public class Placeholder {}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions.jvmTarget = '17'
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/Placeholder.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/Placeholder.kt
@@ -1,0 +1,3 @@
+package gr.tsambala.tutorbilling.domain
+
+class Placeholder

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,3 +15,5 @@ dependencyResolutionManagement {
 
 rootProject.name = 'TutorBillingApp'
 include ':app'
+include ':domain'
+include ':data'


### PR DESCRIPTION
## Summary
- create new `:domain` and `:data` modules
- wire modules in settings and app dependencies
- update changelog

## Testing
- `./gradlew clean` *(passed)*
- `./gradlew assembleDebug` *(failed: unresolved references)*

------
https://chatgpt.com/codex/tasks/task_e_687b8b789b408330b38a12719a93985e