### PR TITLE
feat(domain): add lesson use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Flatten Room migrations; keep only latest schema in data/schemas.
 - Add rebuild walkthrough in `rebuild.md` describing detailed steps.
 - Add domain and data modules for clean architecture foundation.
+- Add AddLesson/GetStudentLessons use-cases and Room DAO tests.
 - Move Room and repository code into `data` module and business utilities into `domain`.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -186,7 +186,7 @@ class LessonViewModel @Inject constructor(
                         notes = state.notes.ifBlank { null },
                         isPaid = state.isPaid
                     )
-                    lessonUseCases.insertLesson(lesson)
+                    lessonUseCases.addLesson(lesson)
                 } else {
                     lessonId?.let { lId ->
                         val lesson = Lesson(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModel.kt
@@ -104,7 +104,7 @@ class RevenueViewModel @Inject constructor(
 
     fun markLessonsPaid(studentId: Long) {
         viewModelScope.launch {
-            val ids = lessonUseCases.getLessonsByStudentId(studentId)
+            val ids = lessonUseCases.getStudentLessons(studentId)
                 .first()
                 .filter { !it.isPaid }
                 .map { it.id }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
@@ -52,7 +52,7 @@ class StudentViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 studentUseCases.getStudentById(studentId),
-                lessonUseCases.getLessonsByStudentId(studentId)
+                lessonUseCases.getStudentLessons(studentId)
             ) { student, lessons -> student to lessons }
                 .catch { e ->
                     _uiState.update { it.copy(errorMessage = e.message) }

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModelTest.kt
@@ -9,13 +9,14 @@ import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.domain.lesson.GetAllLessons
 import gr.tsambala.tutorbilling.domain.lesson.DeleteLesson
 import gr.tsambala.tutorbilling.domain.lesson.GetLessonById
-import gr.tsambala.tutorbilling.domain.lesson.GetLessonsByStudentId
+import gr.tsambala.tutorbilling.domain.lesson.GetStudentLessons
 import gr.tsambala.tutorbilling.domain.lesson.GetLessonsWithStudents
 import gr.tsambala.tutorbilling.domain.lesson.GetLessonsWithStudentsByStudentAndDateRange
-import gr.tsambala.tutorbilling.domain.lesson.InsertLesson
+import gr.tsambala.tutorbilling.domain.lesson.AddLesson
 import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLesson
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonPaidStatus
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
 import gr.tsambala.tutorbilling.domain.student.StudentUseCases
 import gr.tsambala.tutorbilling.domain.student.GetActiveStudents
 import gr.tsambala.tutorbilling.domain.student.GetArchivedStudents
@@ -48,6 +49,7 @@ class RevenueViewModelTest {
     private val studentDao = FakeStudentDao(studentFlow)
     private val lessonDao = FakeLessonDao(lessonFlow)
     private val studentRepository = StudentRepository(studentDao)
+    private val tutorBillingRepository = TutorBillingRepository(studentDao, lessonDao)
     private val studentUseCases = StudentUseCases(
         getActiveStudents = GetActiveStudents(studentRepository),
         getArchivedStudents = GetArchivedStudents(studentRepository),
@@ -62,11 +64,11 @@ class RevenueViewModelTest {
     private val lessonUseCases = LessonUseCases(
         getAllLessons = GetAllLessons(lessonDao),
         getLessonById = GetLessonById(lessonDao),
-        getLessonsByStudentId = GetLessonsByStudentId(lessonDao),
+        getStudentLessons = GetStudentLessons(tutorBillingRepository),
         getLessonsWithStudents = GetLessonsWithStudents(lessonDao),
         getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(lessonDao),
-        insertLesson = InsertLesson(lessonDao),
-        updateLesson = UpdateLesson(lessonDao),
+        addLesson = AddLesson(tutorBillingRepository),
+        updateLesson = UpdateLesson(tutorBillingRepository),
         deleteLesson = DeleteLesson(lessonDao),
         updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
     )

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     ksp "com.google.dagger:hilt-compiler:2.54"
 
     implementation "com.google.android.gms:play-services-auth:21.2.0"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.room:room-testing:2.7.1"
+    testImplementation "androidx.test:core:1.5.0"
+    testImplementation "org.robolectric:robolectric:4.11.1"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
 }
 
 ksp {

--- a/data/src/test/java/gr/tsambala/tutorbilling/data/LessonDaoTest.kt
+++ b/data/src/test/java/gr/tsambala/tutorbilling/data/LessonDaoTest.kt
@@ -1,0 +1,59 @@
+package gr.tsambala.tutorbilling.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LessonDaoTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var lessonDao: LessonDao
+    private lateinit var studentDao: StudentDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        lessonDao = db.lessonDao()
+        studentDao = db.studentDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertAndQueryLessonsByStudent() = runBlocking {
+        val studentId = studentDao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "A", rate = 10.0))
+        lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-01", startTime = "10:00", durationMinutes = 60))
+        val lessons = lessonDao.getLessonsByStudentId(studentId).first()
+        assertEquals(1, lessons.size)
+        assertEquals(studentId, lessons.first().studentId)
+    }
+
+    @Test
+    fun updateLessonPaidStatus() = runBlocking {
+        val studentId = studentDao.insert(Student(name = "Bob", surname = "", parentMobile = "", className = "B", rate = 15.0))
+        val id = lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-02", startTime = "11:00", durationMinutes = 90))
+        lessonDao.updatePaidStatus(listOf(id), true)
+        val lesson = lessonDao.getLessonById(id).first()
+        assertEquals(true, lesson?.isPaid)
+    }
+}

--- a/data/src/test/java/gr/tsambala/tutorbilling/data/StudentDaoTest.kt
+++ b/data/src/test/java/gr/tsambala/tutorbilling/data/StudentDaoTest.kt
@@ -1,0 +1,66 @@
+package gr.tsambala.tutorbilling.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Student
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StudentDaoTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var dao: StudentDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.studentDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertAndQueryStudent() = runBlocking {
+        val id = dao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        val students = dao.getAllActiveStudents().first()
+        assertEquals(1, students.size)
+        assertEquals(id, students.first().id)
+    }
+
+    @Test
+    fun softDeleteAndRestoreStudent() = runBlocking {
+        val id = dao.insert(Student(name = "Bob", surname = "", parentMobile = "", className = "", rate = 12.0))
+        dao.softDeleteStudent(id)
+        val archived = dao.getArchivedStudents().first()
+        assertEquals(1, archived.size)
+        dao.restoreStudent(id)
+        val active = dao.getAllActiveStudents().first()
+        assertEquals(id, active.first().id)
+    }
+
+    @Test
+    fun getStudentByIdAnyReturnsArchived() = runBlocking {
+        val id = dao.insert(Student(name = "Carl", surname = "", parentMobile = "", className = "", rate = 15.0))
+        dao.softDeleteStudent(id)
+        val student = dao.getStudentByIdAny(id).first()
+        assertNotNull(student)
+        assertEquals(false, student?.isActive)
+    }
+}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -27,5 +27,9 @@ dependencies {
     implementation 'javax.inject:javax.inject:1'
     implementation 'com.google.dagger:hilt-core:2.54'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.test:core:1.5.0"
+    testImplementation "org.robolectric:robolectric:4.11.1"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
 }
 

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.repository.StudentRepository
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
 import gr.tsambala.tutorbilling.domain.lesson.*
 import gr.tsambala.tutorbilling.domain.student.*
 import javax.inject.Singleton
@@ -30,15 +31,18 @@ object DomainModule {
 
     @Provides
     @Singleton
-    fun provideLessonUseCases(dao: LessonDao): LessonUseCases =
+    fun provideLessonUseCases(
+        dao: LessonDao,
+        repository: TutorBillingRepository
+    ): LessonUseCases =
         LessonUseCases(
             getAllLessons = GetAllLessons(dao),
             getLessonById = GetLessonById(dao),
-            getLessonsByStudentId = GetLessonsByStudentId(dao),
+            getStudentLessons = GetStudentLessons(repository),
             getLessonsWithStudents = GetLessonsWithStudents(dao),
             getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(dao),
-            insertLesson = InsertLesson(dao),
-            updateLesson = UpdateLesson(dao),
+            addLesson = AddLesson(repository),
+            updateLesson = UpdateLesson(repository),
             deleteLesson = DeleteLesson(dao),
             updateLessonPaidStatus = UpdateLessonPaidStatus(dao)
         )

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/AddLesson.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/AddLesson.kt
@@ -4,8 +4,8 @@ import gr.tsambala.tutorbilling.data.model.Lesson
 import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
 import javax.inject.Inject
 
-class UpdateLesson @Inject constructor(
+class AddLesson @Inject constructor(
     private val repository: TutorBillingRepository
 ) {
-    suspend operator fun invoke(lesson: Lesson) = repository.updateLesson(lesson)
+    suspend operator fun invoke(lesson: Lesson): Long = repository.addLesson(lesson)
 }

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/GetStudentLessons.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/GetStudentLessons.kt
@@ -2,10 +2,12 @@ package gr.tsambala.tutorbilling.domain.lesson
 
 import gr.tsambala.tutorbilling.data.model.Lesson
 import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class UpdateLesson @Inject constructor(
+class GetStudentLessons @Inject constructor(
     private val repository: TutorBillingRepository
 ) {
-    suspend operator fun invoke(lesson: Lesson) = repository.updateLesson(lesson)
+    operator fun invoke(studentId: Long): Flow<List<Lesson>> =
+        repository.getLessonsForStudent(studentId)
 }

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
@@ -5,10 +5,10 @@ import javax.inject.Inject
 data class LessonUseCases @Inject constructor(
     val getAllLessons: GetAllLessons,
     val getLessonById: GetLessonById,
-    val getLessonsByStudentId: GetLessonsByStudentId,
+    val getStudentLessons: GetStudentLessons,
     val getLessonsWithStudents: GetLessonsWithStudents,
     val getLessonsWithStudentsByStudentAndDateRange: GetLessonsWithStudentsByStudentAndDateRange,
-    val insertLesson: InsertLesson,
+    val addLesson: AddLesson,
     val updateLesson: UpdateLesson,
     val deleteLesson: DeleteLesson,
     val updateLessonPaidStatus: UpdateLessonPaidStatus

--- a/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/AddLessonIntegrationTest.kt
+++ b/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/AddLessonIntegrationTest.kt
@@ -1,0 +1,48 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AddLessonIntegrationTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var repository: TutorBillingRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = TutorBillingRepository(db.studentDao(), db.lessonDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun addsLessonToDatabase() = runBlocking {
+        val studentId = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        val lesson = Lesson(studentId = studentId, date = "2024-01-03", startTime = "10:00", durationMinutes = 60)
+        val useCase = AddLesson(repository)
+        useCase(lesson)
+        val lessons = db.lessonDao().getLessonsByStudentId(studentId).first()
+        assertEquals(1, lessons.size)
+    }
+}

--- a/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/GetStudentLessonsTest.kt
+++ b/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/GetStudentLessonsTest.kt
@@ -1,0 +1,47 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GetStudentLessonsTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var repository: TutorBillingRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = TutorBillingRepository(db.studentDao(), db.lessonDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun returnsLessonsForStudent() = runBlocking {
+        val studentId = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        db.lessonDao().insert(Lesson(studentId = studentId, date = "2024-01-01", startTime = "10:00", durationMinutes = 60))
+        val useCase = GetStudentLessons(repository)
+        val lessons = useCase(studentId).first()
+        assertEquals(1, lessons.size)
+    }
+}

--- a/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/UpdateLessonTest.kt
+++ b/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/UpdateLessonTest.kt
@@ -1,0 +1,48 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UpdateLessonTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var repository: TutorBillingRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = TutorBillingRepository(db.studentDao(), db.lessonDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun updatesLesson() = runBlocking {
+        val studentId = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        val id = db.lessonDao().insert(Lesson(studentId = studentId, date = "2024-01-04", startTime = "10:00", durationMinutes = 60))
+        val useCase = UpdateLesson(repository)
+        useCase(Lesson(id = id, studentId = studentId, date = "2024-01-04", startTime = "10:00", durationMinutes = 90))
+        val lesson = db.lessonDao().getLessonById(id).first()
+        assertEquals(90, lesson?.durationMinutes)
+    }
+}


### PR DESCRIPTION
- add AddLesson and GetStudentLessons use cases
- update LessonUseCases and DomainModule to wire repository
- replace insertLesson usages with addLesson
- add in-memory Room DAO tests and use-case tests
- adjust RevenueViewModel test

`./gradlew clean assemble` succeeds but unit tests fail due to restricted Maven downloads.

------
https://chatgpt.com/codex/tasks/task_e_687cbbff74848330ac342b94365fc34e