### PR TITLE
refactor(docs): drop Google Play references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.
 - Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.
-- Enable Play App Signing release builds with keystore placeholders.
 - Make release signingConfig conditional on keystore properties.
 - Integrate Firebase Crashlytics for runtime crash reporting.
 - Optional Google Sign-In with account persisted in DataStore.

--- a/README.md
+++ b/README.md
@@ -38,21 +38,6 @@ Use the Gradle wrapper to build, lint and test the app:
 ./gradlew lintDebug
 ```
 
-### Signing release builds
-
-Release variants require a keystore so the generated APK/AAB can be uploaded to
-Google Play with Play App Signing. Provide the keystore path and credentials via
-Gradle properties or environment variables before running `assembleRelease`:
-
-```bash
-export RELEASE_STORE_FILE=/path/to/keystore.jks
-export RELEASE_STORE_PASSWORD=keystorePassword
-export RELEASE_KEY_ALIAS=releaseKey
-export RELEASE_KEY_PASSWORD=keyPassword
-```
-
-Gradle will pick up these values when assembling the `release` variant.
-
 ## Modules overview
 
 - **app** – main Compose application module containing UI, Hilt dependency injection and Room database code.


### PR DESCRIPTION
## Summary
- remove signing instructions for uploading to Google Play
- drop Play App Signing bullet from changelog

## Testing
- `./gradlew clean` *(passed)*
- `./gradlew assemble` *(failed: build incomplete due to environment limits)*
- `./gradlew test` *(failed: missing dependencies in offline mode)*
- `./gradlew lintDebug` *(failed: stopped early due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687cc33df9f48330bb62cd85bd02f8cb