### PR TITLE
feat(settings): unify styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Reinstate Room auto-migrations up to version 9.
 - Document modules overview in README.
 - Refresh README with build commands and module layout after rebuild.
+- Align Settings screen styling with Revenue screen for consistent Material 3 design.
 
 ## [0.14] - 2025-06-15
 ### Added

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/SettingsScreen.kt
@@ -31,7 +31,11 @@ fun SettingsScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
-                title = { Text("Settings") }
+                title = { Text("Settings") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
             )
         }
     ) { padding ->
@@ -42,31 +46,64 @@ fun SettingsScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            OutlinedTextField(
-                value = settings.currencySymbol,
-                onValueChange = viewModel::updateCurrencySymbol,
-                label = { Text("Currency symbol") }
-            )
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Decimal places: ${settings.roundingDecimals}")
-                Slider(
-                    value = settings.roundingDecimals.toFloat(),
-                    onValueChange = { viewModel.updateRounding(it.toInt()) },
-                    valueRange = 0f..2f,
-                    steps = 1,
-                    modifier = Modifier.weight(1f).padding(start = 8.dp)
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                OutlinedTextField(
+                    value = settings.currencySymbol,
+                    onValueChange = viewModel::updateCurrencySymbol,
+                    label = { Text("Currency symbol") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
                 )
             }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Dark theme")
-                Spacer(Modifier.width(8.dp))
-                Switch(
-                    checked = settings.darkTheme,
-                    onCheckedChange = viewModel::updateDarkTheme
-                )
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text("Decimal places: ${settings.roundingDecimals}")
+                    Slider(
+                        value = settings.roundingDecimals.toFloat(),
+                        onValueChange = { viewModel.updateRounding(it.toInt()) },
+                        valueRange = 0f..2f,
+                        steps = 1,
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(start = 8.dp)
+                    )
+                }
+            }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text("Dark theme")
+                    Switch(
+                        checked = settings.darkTheme,
+                        onCheckedChange = viewModel::updateDarkTheme
+                    )
+                }
             }
 
-            TextButton(onClick = onPrivacyPolicy) {
+            OutlinedButton(
+                onClick = onPrivacyPolicy,
+                modifier = Modifier.fillMaxWidth()
+            ) {
                 Text(stringResource(R.string.privacy_policy))
             }
         }


### PR DESCRIPTION
- WHAT changed
  - Updated SettingsScreen to use Material3 AppBar colors, full-width inputs, and consistent Card layout
  - Replaced TextButton with OutlinedButton for privacy policy link
  - Documented change in CHANGELOG
- WHY it matters
  - Provides visual consistency across screens using uniform Material3 components
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_687cdcb9d624833082a43a02e332e648