### PR TITLE
fix(ui): unify top bar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Document modules overview in README.
 - Refresh README with build commands and module layout after rebuild.
 - Align Settings screen styling with Revenue screen for consistent Material 3 design.
+- Apply `primaryContainer` colors to remaining screens' top app bars.
 
 ## [0.14] - 2025-06-15
 ### Added

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceScreen.kt
@@ -65,7 +65,11 @@ fun InvoiceScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             )
         },
         bottomBar = {

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/PastInvoicesScreen.kt
@@ -38,7 +38,11 @@ fun PastInvoicesScreen(onBack: () -> Unit) {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             )
         }
     ) { padding ->

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -81,7 +81,11 @@ fun LessonScreen(
                             }
                         )
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/PrivacyPolicyScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/settings/PrivacyPolicyScreen.kt
@@ -25,7 +25,11 @@ fun PrivacyPolicyScreen(onBack: () -> Unit) {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
             )
         }
     ) { padding ->


### PR DESCRIPTION
- WHAT changed
  - updated remaining screens to use `primaryContainer` for top app bar background
  - documented change in CHANGELOG
- WHY it matters
  - ensures consistent theming across the app
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_687ce889b240833093642d9d235f061a