### PR TITLE
feat(home): dynamic class count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Make release signingConfig conditional on keystore properties.
 - Integrate Firebase Crashlytics for runtime crash reporting.
 - Removed Google Sign-In feature and account persistence.
+- Show Classes button highlighted when a valid class exists.
 - In-app privacy policy screen linked from Settings.
 - Provide Hilt modules for DAOs and repositories.
 - Expose domain use-cases and inject them into ViewModels.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,6 +129,7 @@ android {
     testImplementation "androidx.test:core:1.5.0"
     testImplementation "org.robolectric:robolectric:4.11.1"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
+    testImplementation "androidx.compose.ui:ui-test-junit4"
     androidTestImplementation "androidx.test.ext:junit:1.2.1"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.6.1"
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModel.kt
@@ -31,7 +31,11 @@ class HomeMenuViewModel @Inject constructor(
                 studentUseCases.getActiveStudents(),
                 lessonUseCases.getAllLessons()
             ) { students, lessons ->
-                val classCount = 0
+                val classCount = students
+                    .map { it.className }
+                    .filterNot { it.isBlank() || it.equals("unknown", true) }
+                    .distinct()
+                    .size
 
                 val today = LocalDate.now()
                 val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModelTest.kt
@@ -1,0 +1,127 @@
+package gr.tsambala.tutorbilling.ui.home
+
+import gr.tsambala.tutorbilling.MainDispatcherRule
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.repository.StudentRepository
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import gr.tsambala.tutorbilling.domain.lesson.AddLesson
+import gr.tsambala.tutorbilling.domain.lesson.DeleteLesson
+import gr.tsambala.tutorbilling.domain.lesson.GetAllLessons
+import gr.tsambala.tutorbilling.domain.lesson.GetLessonById
+import gr.tsambala.tutorbilling.domain.lesson.GetLessonsWithStudents
+import gr.tsambala.tutorbilling.domain.lesson.GetLessonsWithStudentsByStudentAndDateRange
+import gr.tsambala.tutorbilling.domain.lesson.GetStudentLessons
+import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
+import gr.tsambala.tutorbilling.domain.lesson.UpdateLesson
+import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonPaidStatus
+import gr.tsambala.tutorbilling.domain.student.ClassNameExists
+import gr.tsambala.tutorbilling.domain.student.GetActiveStudentCount
+import gr.tsambala.tutorbilling.domain.student.GetActiveStudents
+import gr.tsambala.tutorbilling.domain.student.GetArchivedStudents
+import gr.tsambala.tutorbilling.domain.student.GetStudentById
+import gr.tsambala.tutorbilling.domain.student.InsertStudent
+import gr.tsambala.tutorbilling.domain.student.RestoreStudent
+import gr.tsambala.tutorbilling.domain.student.SoftDeleteStudent
+import gr.tsambala.tutorbilling.domain.student.StudentUseCases
+import gr.tsambala.tutorbilling.domain.student.UpdateStudent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HomeMenuViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
+    private val lessonFlow = MutableStateFlow<List<Lesson>>(emptyList())
+
+    private val studentDao = FakeStudentDao(studentFlow)
+    private val lessonDao = FakeLessonDao(lessonFlow)
+    private val studentRepository = StudentRepository(studentDao)
+    private val tutorBillingRepository = TutorBillingRepository(studentDao, lessonDao)
+    private val studentUseCases = StudentUseCases(
+        getActiveStudents = GetActiveStudents(studentRepository),
+        getArchivedStudents = GetArchivedStudents(studentRepository),
+        getStudentById = GetStudentById(studentRepository),
+        insertStudent = InsertStudent(studentRepository),
+        updateStudent = UpdateStudent(studentRepository),
+        softDeleteStudent = SoftDeleteStudent(studentRepository),
+        restoreStudent = RestoreStudent(studentRepository),
+        getActiveStudentCount = GetActiveStudentCount(studentRepository),
+        classNameExists = ClassNameExists(studentRepository)
+    )
+    private val lessonUseCases = LessonUseCases(
+        getAllLessons = GetAllLessons(lessonDao),
+        getLessonById = GetLessonById(lessonDao),
+        getStudentLessons = GetStudentLessons(tutorBillingRepository),
+        getLessonsWithStudents = GetLessonsWithStudents(lessonDao),
+        getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(lessonDao),
+        addLesson = AddLesson(tutorBillingRepository),
+        updateLesson = UpdateLesson(tutorBillingRepository),
+        deleteLesson = DeleteLesson(lessonDao),
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
+    )
+
+    @Test
+    fun classCountReflectsDistinctClasses() = runTest {
+        val vm = HomeMenuViewModel(studentUseCases, lessonUseCases)
+        advanceUntilIdle()
+        assertEquals(0, vm.uiState.value.classCount)
+
+        val s1 = Student(id = 1, name = "Alice", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        val s2 = Student(id = 2, name = "Bob", surname = "", parentMobile = "", className = "unknown", rate = 10.0)
+        val s3 = Student(id = 3, name = "Carol", surname = "", parentMobile = "", className = "B", rate = 10.0)
+        val s4 = Student(id = 4, name = "Dan", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        studentFlow.value = listOf(s1, s2, s3, s4)
+        advanceUntilIdle()
+        assertEquals(2, vm.uiState.value.classCount)
+    }
+
+    class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
+        override suspend fun insert(student: Student): Long { flow.value += student; return student.id }
+        override suspend fun update(student: Student) {}
+        override suspend fun delete(student: Student) {}
+        override suspend fun softDeleteStudent(studentId: Long) {}
+        override fun getStudentById(studentId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
+        override fun getAllActiveStudents(): Flow<List<Student>> = flow.asStateFlow()
+        override fun getArchivedStudents(): Flow<List<Student>> = flowOf(emptyList())
+        override suspend fun restoreStudent(studentId: Long) {}
+        override fun getStudentByIdAny(studentId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
+        override suspend fun getActiveStudentCount(): Int = flow.value.size
+        override suspend fun classNameExists(name: String): Int = flow.value.count { it.className.equals(name, true) }
+    }
+
+    class FakeLessonDao(private val flow: MutableStateFlow<List<Lesson>>) : LessonDao {
+        override suspend fun insert(lesson: Lesson): Long { flow.value += lesson; return lesson.id }
+        override suspend fun update(lesson: Lesson) {}
+        override suspend fun delete(lesson: Lesson) {}
+        override suspend fun deleteById(lessonId: Long) {}
+        override fun getLessonById(lessonId: Long): Flow<Lesson?> = flow.map { it.find { l -> l.id == lessonId } }
+        override fun getLessonsByStudentId(studentId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.studentId == studentId } }
+        override fun getAllLessons(): Flow<List<Lesson>> = flow.asStateFlow()
+        override fun getLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
+        override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
+        override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
+        override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
+        override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {}
+        override fun getLessonsWithStudents(): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+        override fun getLessonsWithStudentsByStudent(studentId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+        override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+        override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+    }
+}


### PR DESCRIPTION
- compute unique class count in `HomeMenuViewModel`
- expose it through UI state
- add regression test verifying class count

Checklist:
* [ ] `CHANGELOG.md` updated
* [ ] Unit tests passing
* [ ] Lint shows **0** new warnings
* [ ] `./gradlew assemble` succeeds on CI

------
https://chatgpt.com/codex/tasks/task_e_687d620c70c48330ac6f689853a31be6