### PR TITLE
fix(student): optional mobile contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Show student surname in all UI lists using `getFullName()` extension.
 - Make release signingConfig conditional on keystore properties.
 - Integrate Firebase Crashlytics for runtime crash reporting.
+- Allow saving students without a phone number and warn if no contact details are provided.
 - Removed Google Sign-In feature and account persistence.
 - Show Classes button highlighted when a valid class exists.
 - In-app privacy policy screen linked from Settings.

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -371,6 +371,7 @@ private fun StudentEditForm(
     val nameError = uiState.name.isBlank()
     val rateValue = uiState.rate.toDoubleOrNull()
     val rateError = rateValue == null || rateValue <= 0.0
+    var showContactWarning by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -401,12 +402,12 @@ private fun StudentEditForm(
             singleLine = true
         )
 
-        val mobileError =
-            uiState.parentMobile.length != 10 || uiState.parentMobile.any { !it.isDigit() }
+        val mobileError = uiState.parentMobile.isNotBlank() &&
+            uiState.parentMobile.length != 10
         OutlinedTextField(
             value = uiState.parentMobile,
             onValueChange = viewModel::updateParentMobile,
-            label = { Text("Parent's Mobile*") },
+            label = { Text("Parent's Mobile") },
             isError = mobileError,
             supportingText = { if (mobileError) Text("10-digit number") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
@@ -532,12 +533,16 @@ private fun StudentEditForm(
                 Text("Cancel")
             }
             Button(
-                onClick = onSave,
+                onClick = {
+                    if (uiState.parentMobile.isBlank() && uiState.parentEmail.isBlank()) {
+                        showContactWarning = true
+                    } else {
+                        onSave()
+                    }
+                },
                 modifier = Modifier.weight(1f),
                 enabled = uiState.name.isNotBlank() &&
                     uiState.surname.isNotBlank() &&
-                    uiState.parentMobile.length == 10 &&
-                    uiState.parentMobile.all { it.isDigit() } &&
                     rateValue != null && rateValue > 0 &&
                     uiState.selectedClass.isNotBlank() &&
                     (uiState.selectedClass != "Custom" || uiState.customClass.isNotBlank()) &&
@@ -546,6 +551,22 @@ private fun StudentEditForm(
             ) {
                 Text("Save")
             }
+        }
+        if (showContactWarning) {
+            AlertDialog(
+                onDismissRequest = { showContactWarning = false },
+                title = { Text(stringResource(R.string.contact_details_missing_title)) },
+                text = { Text(stringResource(R.string.contact_details_missing_message)) },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showContactWarning = false
+                        onSave()
+                    }) { Text(stringResource(R.string.proceed)) }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showContactWarning = false }) { Text(stringResource(R.string.cancel)) }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentViewModel.kt
@@ -148,8 +148,6 @@ class StudentViewModel @Inject constructor(
         val state = _uiState.value
         val rate = state.rate.toDoubleOrNull()?.takeIf { it > 0 } ?: return
 
-        if (state.parentMobile.length != 10) return
-
         if (state.parentEmail.isNotBlank() &&
             !Patterns.EMAIL_ADDRESS.matcher(state.parentEmail).matches()) {
             return
@@ -166,12 +164,13 @@ class StudentViewModel @Inject constructor(
                     }
                     return@launch
                 }
+                val mobile = if (state.parentMobile.length == 10) state.parentMobile else ""
                 val student = if (studentId > 0) {
                     Student(
                         id = studentId,
                         name = state.name,
                         surname = state.surname,
-                        parentMobile = state.parentMobile,
+                        parentMobile = mobile,
                         parentEmail = state.parentEmail.ifBlank { null },
                         className = className,
                         rate = rate,
@@ -182,7 +181,7 @@ class StudentViewModel @Inject constructor(
                     Student(
                         name = state.name,
                         surname = state.surname,
-                        parentMobile = state.parentMobile,
+                        parentMobile = mobile,
                         parentEmail = state.parentEmail.ifBlank { null },
                         className = className,
                         rate = rate,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="validation_error_empty_name">Please enter a student name</string>
     <string name="validation_error_invalid_rate">Please enter a valid rate</string>
     <string name="validation_error_invalid_duration">Please enter a valid duration</string>
+    <string name="contact_details_missing_title">No Contact Details</string>
+    <string name="contact_details_missing_message">This student has no phone number or email. Continue anyway?</string>
+    <string name="proceed">Proceed</string>
     <string name="app_logo_desc">App logo</string>
 
     <!-- Privacy policy -->


### PR DESCRIPTION
- allow empty mobile numbers and only show error when partially filled
- drop mobile validation check from Save button
- save empty mobile in view model and warn if no contact info provided

To test:
- `./gradlew clean assemble` *(may fail in limited env)*
- `./gradlew test`
- `./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_687d689bfdc8833087ba895814e55cc7