### PR TITLE
feat(invoicing): track invoiced lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add domain and data modules for clean architecture foundation.
 - Add AddLesson/GetStudentLessons use-cases and Room DAO tests.
 - Move Room and repository code into `data` module and business utilities into `domain`.
+- Track invoicing state on lessons and prompt when toggling paid status.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.
 - Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -63,9 +63,9 @@ fun TutorBillingApp() {
                         Screen.Lesson.createRoute(lessonId, studentId)
                     )
                 },
-                onAddLesson = {
-                    navController.navigate(Screen.Lesson.createRoute(0))
-                }
+                onAddLesson = { navController.navigate(Screen.Lesson.createRoute(0)) },
+                onInvoice = { id -> navController.navigate(Screen.Invoice.createRoute(id)) },
+                onPastInvoices = { navController.navigate(Screen.PastInvoices.route) }
             )
         }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModel.kt
@@ -81,6 +81,9 @@ class InvoiceViewModel @Inject constructor(
     }
 
     fun markAsPaid(ids: List<Long>) {
-        viewModelScope.launch { lessonUseCases.updateLessonPaidStatus(ids, true) }
+        viewModelScope.launch {
+            lessonUseCases.updateLessonPaidStatus(ids, true)
+            lessonUseCases.updateLessonInvoicedStatus(ids, true)
+        }
     }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -29,6 +29,8 @@ fun LessonsScreen(
     onBack: () -> Unit,
     onLessonClick: (Long, Long) -> Unit,
     onAddLesson: () -> Unit,
+    onInvoice: (Long?) -> Unit,
+    onPastInvoices: () -> Unit,
     viewModel: LessonsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -82,6 +84,49 @@ fun LessonsScreen(
                 }
             }
         }
+    }
+
+    when (val dialog = uiState.dialog) {
+        is LessonDialog.AlreadyInvoiced -> {
+            AlertDialog(
+                onDismissRequest = { viewModel.dismissDialog() },
+                title = { Text(stringResource(R.string.already_invoiced_title)) },
+                confirmButton = {
+                    TextButton(onClick = { viewModel.applyPaidStatus(dialog.lessonId, dialog.paid) }) {
+                        Text(stringResource(R.string.force_toggle))
+                    }
+                },
+                dismissButton = {
+                    Row {
+                        TextButton(onClick = { onPastInvoices(); viewModel.dismissDialog() }) {
+                            Text(stringResource(R.string.view_past_invoice))
+                        }
+                        TextButton(onClick = { viewModel.dismissDialog() }) {
+                            Text(stringResource(R.string.cancel))
+                        }
+                    }
+                }
+            )
+        }
+        is LessonDialog.GenerateInvoice -> {
+            AlertDialog(
+                onDismissRequest = { viewModel.dismissDialog() },
+                title = { Text(stringResource(R.string.generate_invoice)) },
+                text = { Text(stringResource(R.string.generate_invoice_prompt)) },
+                confirmButton = {
+                    TextButton(onClick = {
+                        viewModel.applyPaidStatus(dialog.lessonId, true)
+                        onInvoice(dialog.studentId)
+                    }) { Text(stringResource(R.string.generate_invoice)) }
+                },
+                dismissButton = {
+                    TextButton(onClick = { viewModel.applyPaidStatus(dialog.lessonId, true) }) {
+                        Text(stringResource(R.string.cancel))
+                    }
+                }
+            )
+        }
+        null -> {}
     }
 }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.tsambala.tutorbilling.data.database.LessonWithStudent
 import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,11 +31,34 @@ class LessonsViewModel @Inject constructor(
 
     fun updatePaid(lessonId: Long, paid: Boolean) {
         viewModelScope.launch {
-            lessonUseCases.updateLessonPaidStatus(listOf(lessonId), paid)
+            val invoiced = lessonUseCases.isLessonInvoiced(lessonId).first() ?: false
+            val lesson = _uiState.value.lessons.find { it.lesson.id == lessonId }
+            if (invoiced) {
+                _uiState.update { it.copy(dialog = LessonDialog.AlreadyInvoiced(lessonId, paid)) }
+            } else if (paid && lesson != null) {
+                _uiState.update { it.copy(dialog = LessonDialog.GenerateInvoice(lessonId, lesson.student.id)) }
+            } else {
+                lessonUseCases.updateLessonPaidStatus(listOf(lessonId), paid)
+            }
         }
+    }
+
+    fun applyPaidStatus(lessonId: Long, paid: Boolean) {
+        viewModelScope.launch { lessonUseCases.updateLessonPaidStatus(listOf(lessonId), paid) }
+        _uiState.update { it.copy(dialog = null) }
+    }
+
+    fun dismissDialog() {
+        _uiState.update { it.copy(dialog = null) }
     }
 }
 
 data class LessonsUiState(
-    val lessons: List<LessonWithStudent> = emptyList()
+    val lessons: List<LessonWithStudent> = emptyList(),
+    val dialog: LessonDialog? = null
 )
+
+sealed interface LessonDialog {
+    data class AlreadyInvoiced(val lessonId: Long, val paid: Boolean) : LessonDialog
+    data class GenerateInvoice(val lessonId: Long, val studentId: Long) : LessonDialog
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,11 @@
     <string name="validation_error_invalid_rate">Please enter a valid rate</string>
     <string name="validation_error_invalid_duration">Please enter a valid duration</string>
     <string name="app_logo_desc">App logo</string>
+    <string name="already_invoiced_title">Lesson already invoiced</string>
+    <string name="view_past_invoice">View Past Invoice</string>
+    <string name="force_toggle">Force Toggle</string>
+    <string name="generate_invoice_prompt">Generate invoice for this lesson?</string>
+    <string name="generate_invoice">Generate Invoice</string>
 
     <!-- Privacy policy -->
     <string name="privacy_policy">Privacy Policy</string>

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/invoice/InvoiceViewModelTest.kt
@@ -1,0 +1,115 @@
+package gr.tsambala.tutorbilling.ui.invoice
+
+import androidx.lifecycle.SavedStateHandle
+import gr.tsambala.tutorbilling.MainDispatcherRule
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.repository.StudentRepository
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import gr.tsambala.tutorbilling.domain.lesson.*
+import gr.tsambala.tutorbilling.domain.student.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InvoiceViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
+    private val lessonFlow = MutableStateFlow<List<Lesson>>(emptyList())
+
+    private val studentDao = object : StudentDao {
+        override suspend fun insert(student: Student): Long { studentFlow.value += student; return student.id }
+        override suspend fun update(student: Student) {}
+        override suspend fun delete(student: Student) {}
+        override suspend fun softDeleteStudent(studentId: Long) {}
+        override fun getStudentById(studentId: Long) = studentFlow.map { list -> list.find { it.id == studentId } }
+        override fun getAllActiveStudents() = studentFlow.asStateFlow()
+        override fun getArchivedStudents() = flowOf(emptyList<Student>())
+        override suspend fun restoreStudent(studentId: Long) {}
+        override fun getStudentByIdAny(studentId: Long) = getStudentById(studentId)
+        override suspend fun getActiveStudentCount() = studentFlow.value.size
+        override suspend fun classNameExists(name: String) = 0
+    }
+
+    private val lessonDao = object : LessonDao {
+        override suspend fun insert(lesson: Lesson): Long { lessonFlow.value += lesson; return lesson.id }
+        override suspend fun update(lesson: Lesson) {}
+        override suspend fun delete(lesson: Lesson) {}
+        override suspend fun deleteById(lessonId: Long) {}
+        override fun getLessonById(lessonId: Long) = lessonFlow.map { it.find { l -> l.id == lessonId } }
+        override fun getLessonsByStudentId(studentId: Long) = lessonFlow.map { list -> list.filter { it.studentId == studentId } }
+        override fun getAllLessons() = lessonFlow.asStateFlow()
+        override fun getLessonsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {
+            lessonFlow.value = lessonFlow.value.map { if (it.id in ids) it.copy(isPaid = paid) else it }
+        }
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
+            lessonFlow.value = lessonFlow.value.map { if (it.id in ids) it.copy(isInvoiced = invoiced) else it }
+        }
+        override fun isLessonInvoiced(lessonId: Long) = lessonFlow.map { list -> list.find { it.id == lessonId }?.isInvoiced }
+        override fun getLessonsWithStudents() = flowOf(emptyList<gr.tsambala.tutorbilling.data.database.LessonWithStudent>())
+        override fun getLessonsWithStudentsByStudent(studentId: Long) = flowOf(emptyList<gr.tsambala.tutorbilling.data.database.LessonWithStudent>())
+        override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<gr.tsambala.tutorbilling.data.database.LessonWithStudent>())
+        override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<gr.tsambala.tutorbilling.data.database.LessonWithStudent>())
+    }
+
+    private val studentRepository = StudentRepository(studentDao)
+    private val tutorBillingRepository = TutorBillingRepository(studentDao, lessonDao)
+
+    private val studentUseCases = StudentUseCases(
+        getActiveStudents = GetActiveStudents(studentRepository),
+        getArchivedStudents = GetArchivedStudents(studentRepository),
+        getStudentById = GetStudentById(studentRepository),
+        insertStudent = InsertStudent(studentRepository),
+        updateStudent = UpdateStudent(studentRepository),
+        softDeleteStudent = SoftDeleteStudent(studentRepository),
+        restoreStudent = RestoreStudent(studentRepository),
+        getActiveStudentCount = GetActiveStudentCount(studentRepository),
+        classNameExists = ClassNameExists(studentRepository)
+    )
+
+    private val lessonUseCases = LessonUseCases(
+        getAllLessons = GetAllLessons(lessonDao),
+        getLessonById = GetLessonById(lessonDao),
+        getStudentLessons = GetStudentLessons(tutorBillingRepository),
+        getLessonsWithStudents = GetLessonsWithStudents(lessonDao),
+        getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(lessonDao),
+        addLesson = AddLesson(tutorBillingRepository),
+        updateLesson = UpdateLesson(tutorBillingRepository),
+        deleteLesson = DeleteLesson(lessonDao),
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
+    )
+
+    @Test
+    fun markAsPaidMarksInvoiced() = runTest {
+        val student = Student(id = 1, name = "Alice", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        studentFlow.value = listOf(student)
+        val lesson = Lesson(id = 1, studentId = 1, date = "2024-01-01", startTime = "10:00", durationMinutes = 60)
+        lessonFlow.value = listOf(lesson)
+
+        val vm = InvoiceViewModel(SavedStateHandle(), lessonUseCases, studentUseCases)
+        vm.markAsPaid(listOf(1))
+        advanceUntilIdle()
+
+        assertEquals(true, lessonFlow.value.first().isInvoiced)
+    }
+}

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
@@ -1,0 +1,96 @@
+package gr.tsambala.tutorbilling.ui.lessons
+
+import gr.tsambala.tutorbilling.MainDispatcherRule
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.database.LessonWithStudent
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.domain.lesson.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LessonsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val lessonFlow = MutableStateFlow<List<LessonWithStudent>>(emptyList())
+
+    private val lessonDao = object : LessonDao {
+        override suspend fun insert(lesson: Lesson): Long = 0
+        override suspend fun update(lesson: Lesson) {}
+        override suspend fun delete(lesson: Lesson) {}
+        override suspend fun deleteById(lessonId: Long) {}
+        override fun getLessonById(lessonId: Long) = flowOf(null)
+        override fun getLessonsByStudentId(studentId: Long) = flowOf(emptyList<Lesson>())
+        override fun getAllLessons() = flowOf(emptyList<Lesson>())
+        override fun getLessonsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<Lesson>())
+        override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {
+            lessonFlow.value = lessonFlow.value.map {
+                if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isPaid = paid)) else it
+            }
+        }
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {}
+        override fun isLessonInvoiced(lessonId: Long) = lessonFlow.map { list -> list.find { it.lesson.id == lessonId }?.lesson?.isInvoiced }
+        override fun getLessonsWithStudents() = lessonFlow.asStateFlow()
+        override fun getLessonsWithStudentsByStudent(studentId: Long) = flowOf(emptyList<LessonWithStudent>())
+        override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String) = flowOf(emptyList<LessonWithStudent>())
+        override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String) = flowOf(emptyList<LessonWithStudent>())
+    }
+
+    private val useCases = LessonUseCases(
+        getAllLessons = GetAllLessons(lessonDao),
+        getLessonById = GetLessonById(lessonDao),
+        getStudentLessons = GetStudentLessons(TutorBillingRepositoryFake()),
+        getLessonsWithStudents = GetLessonsWithStudents(lessonDao),
+        getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(lessonDao),
+        addLesson = AddLesson(TutorBillingRepositoryFake()),
+        updateLesson = UpdateLesson(TutorBillingRepositoryFake()),
+        deleteLesson = DeleteLesson(lessonDao),
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
+    )
+
+    @Test
+    fun updatePaidShowsGenerateInvoice() = runTest {
+        val student = Student(id = 1, name = "Bob", surname = "", parentMobile = "", className = "B", rate = 10.0)
+        val lesson = Lesson(id = 1, studentId = 1, date = "2024-01-01", startTime = "10:00", durationMinutes = 60)
+        lessonFlow.value = listOf(LessonWithStudent(lesson, student))
+        val vm = LessonsViewModel(useCases)
+        advanceUntilIdle()
+        vm.updatePaid(1, true)
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.dialog is LessonDialog.GenerateInvoice)
+    }
+
+    private class TutorBillingRepositoryFake : gr.tsambala.tutorbilling.data.repository.TutorBillingRepository(
+        studentDao = object : gr.tsambala.tutorbilling.data.dao.StudentDao {
+            override suspend fun insert(student: Student) = 0L
+            override suspend fun update(student: Student) {}
+            override suspend fun delete(student: Student) {}
+            override suspend fun softDeleteStudent(studentId: Long) {}
+            override fun getStudentById(studentId: Long) = flowOf(null)
+            override fun getAllActiveStudents() = flowOf(emptyList<Student>())
+            override fun getArchivedStudents() = flowOf(emptyList<Student>())
+            override suspend fun restoreStudent(studentId: Long) {}
+            override fun getStudentByIdAny(studentId: Long) = flowOf(null)
+            override suspend fun getActiveStudentCount() = 0
+            override suspend fun classNameExists(name: String) = 0
+        },
+        lessonDao = lessonDao
+    )
+}

--- a/data/schemas/gr.tsambala.tutorbilling.data.database.TutorBillingDatabase/10.json
+++ b/data/schemas/gr.tsambala.tutorbilling.data.database.TutorBillingDatabase/10.json
@@ -1,0 +1,178 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "3a91fdadd58180214d1135f4d7f9a159",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `studentId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3a91fdadd58180214d1135f4d7f9a159')"
+    ]
+  }
+}

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
@@ -43,6 +43,12 @@ interface LessonDao {
     @Query("UPDATE lessons SET isPaid = :paid WHERE id IN (:ids)")
     suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean)
 
+    @Query("UPDATE lessons SET isInvoiced = :invoiced WHERE id IN (:ids)")
+    suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean)
+
+    @Query("SELECT isInvoiced FROM lessons WHERE id = :lessonId")
+    fun isLessonInvoiced(lessonId: Long): Flow<Boolean?>
+
     @Transaction
     @Query(
         """
@@ -53,6 +59,7 @@ interface LessonDao {
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
                lessons.isPaid AS lesson_isPaid,
+               lessons.isInvoiced AS lesson_isInvoiced,
                students.id AS student_id,
                students.name AS student_name,
                students.surname AS student_surname,
@@ -78,6 +85,7 @@ interface LessonDao {
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
                lessons.isPaid AS lesson_isPaid,
+               lessons.isInvoiced AS lesson_isInvoiced,
                students.id AS student_id,
                students.name AS student_name,
                students.surname AS student_surname,
@@ -104,6 +112,7 @@ interface LessonDao {
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
                lessons.isPaid AS lesson_isPaid,
+               lessons.isInvoiced AS lesson_isInvoiced,
                students.id AS student_id,
                students.name AS student_name,
                students.surname AS student_surname,
@@ -130,6 +139,7 @@ interface LessonDao {
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
                lessons.isPaid AS lesson_isPaid,
+               lessons.isInvoiced AS lesson_isInvoiced,
                students.id AS student_id,
                students.name AS student_name,
                students.surname AS student_surname,

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -13,13 +13,14 @@ import gr.tsambala.tutorbilling.data.model.Student
 
 @Database(
     entities = [Student::class, Lesson::class],
-    version = 9, // Current version
+    version = 10, // Current version
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
-        AutoMigration(from = 8, to = 9)
+        AutoMigration(from = 8, to = 9),
+        AutoMigration(from = 9, to = 10)
     ]
 )
 abstract class TutorBillingDatabase : RoomDatabase() {

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
@@ -33,7 +33,9 @@ data class Lesson(
     val durationMinutes: Int,
     val notes: String? = null,
     @ColumnInfo(defaultValue = "0")
-    val isPaid: Boolean = false // Default to false (0 in database)
+    val isPaid: Boolean = false, // Default to false (0 in database)
+    @ColumnInfo(defaultValue = "0")
+    val isInvoiced: Boolean = false
 ) {
     // Helper functions for date/time conversion
     fun getLocalDate(): LocalDate = LocalDate.parse(date)
@@ -46,7 +48,8 @@ data class Lesson(
             startTime: LocalTime,
             durationMinutes: Int,
             notes: String? = null,
-            isPaid: Boolean = false
+            isPaid: Boolean = false,
+            isInvoiced: Boolean = false
         ): Lesson {
             return Lesson(
                 studentId = studentId,
@@ -54,7 +57,8 @@ data class Lesson(
                 startTime = startTime.toString(),
                 durationMinutes = durationMinutes,
                 notes = notes,
-                isPaid = isPaid
+                isPaid = isPaid,
+                isInvoiced = isInvoiced
             )
         }
     }

--- a/data/src/test/java/gr/tsambala/tutorbilling/data/LessonDaoTest.kt
+++ b/data/src/test/java/gr/tsambala/tutorbilling/data/LessonDaoTest.kt
@@ -56,4 +56,13 @@ class LessonDaoTest {
         val lesson = lessonDao.getLessonById(id).first()
         assertEquals(true, lesson?.isPaid)
     }
+
+    @Test
+    fun updateLessonInvoicedStatus() = runBlocking {
+        val studentId = studentDao.insert(Student(name = "Cara", surname = "", parentMobile = "", className = "C", rate = 12.0))
+        val id = lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-03", startTime = "12:00", durationMinutes = 60))
+        lessonDao.updateInvoicedStatus(listOf(id), true)
+        val invoiced = lessonDao.isLessonInvoiced(id).first()
+        assertEquals(true, invoiced)
+    }
 }

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
@@ -44,6 +44,8 @@ object DomainModule {
             addLesson = AddLesson(repository),
             updateLesson = UpdateLesson(repository),
             deleteLesson = DeleteLesson(dao),
-            updateLessonPaidStatus = UpdateLessonPaidStatus(dao)
+            updateLessonPaidStatus = UpdateLessonPaidStatus(dao),
+            updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(dao),
+            isLessonInvoiced = IsLessonInvoiced(dao)
         )
 }

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/IsLessonInvoiced.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/IsLessonInvoiced.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class IsLessonInvoiced @Inject constructor(
+    private val dao: LessonDao
+) {
+    operator fun invoke(id: Long): Flow<Boolean?> = dao.isLessonInvoiced(id)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
@@ -11,5 +11,7 @@ data class LessonUseCases @Inject constructor(
     val addLesson: AddLesson,
     val updateLesson: UpdateLesson,
     val deleteLesson: DeleteLesson,
-    val updateLessonPaidStatus: UpdateLessonPaidStatus
+    val updateLessonPaidStatus: UpdateLessonPaidStatus,
+    val updateLessonInvoicedStatus: UpdateLessonInvoicedStatus,
+    val isLessonInvoiced: IsLessonInvoiced
 )

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/UpdateLessonInvoicedStatus.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/UpdateLessonInvoicedStatus.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import gr.tsambala.tutorbilling.data.dao.LessonDao
+import javax.inject.Inject
+
+class UpdateLessonInvoicedStatus @Inject constructor(
+    private val dao: LessonDao
+) {
+    suspend operator fun invoke(ids: List<Long>, invoiced: Boolean) =
+        dao.updateInvoicedStatus(ids, invoiced)
+}


### PR DESCRIPTION
- add `isInvoiced` column to `Lesson` and Room schema v10
- auto‑migrate database and expose invoiced queries
- mark invoiced lessons when generating an invoice
- prompt users about invoices before toggling paid status
- new dialog resources and unit tests for invoice logic

`./gradlew clean assemble test lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_687d68ba5c808330951e7c7aa1b29a53