### PR TITLE
test(lessons): update paid dialog cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add domain and data modules for clean architecture foundation.
 - Add AddLesson/GetStudentLessons use-cases and Room DAO tests.
 - Move Room and repository code into `data` module and business utilities into `domain`.
+- Reintroduce LessonsViewModel.updatePaid tests for invoicing prompts.
 - Track invoicing state on lessons and prompt when toggling paid status.
 - Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
@@ -38,7 +38,7 @@ class LessonsViewModel @Inject constructor(
     fun updatePaid(lessonId: Long, paid: Boolean) {
         viewModelScope.launch {
             val invoiced = lessonUseCases.isLessonInvoiced(lessonId).first() ?: false
-            val lesson = _uiState.value.lessons.find { it.lesson.id == lessonId }
+            val lesson = _uiState.value.lessons.values.flatten().find { it.lesson.id == lessonId }
             if (invoiced) {
                 _uiState.update { it.copy(dialog = LessonDialog.AlreadyInvoiced(lessonId, paid)) }
             } else if (paid && lesson != null) {
@@ -60,7 +60,7 @@ class LessonsViewModel @Inject constructor(
 }
 
 data class LessonsUiState(
-    val lessons: List<LessonWithStudent> = emptyList(),
+    val lessons: Map<Long, List<LessonWithStudent>> = emptyMap(),
     val dialog: LessonDialog? = null
 )
 

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/home/HomeMenuViewModelTest.kt
@@ -18,6 +18,8 @@ import gr.tsambala.tutorbilling.domain.lesson.GetStudentLessons
 import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLesson
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonPaidStatus
+import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonInvoicedStatus
+import gr.tsambala.tutorbilling.domain.lesson.IsLessonInvoiced
 import gr.tsambala.tutorbilling.domain.student.ClassNameExists
 import gr.tsambala.tutorbilling.domain.student.GetActiveStudentCount
 import gr.tsambala.tutorbilling.domain.student.GetActiveStudents
@@ -74,7 +76,9 @@ class HomeMenuViewModelTest {
         addLesson = AddLesson(tutorBillingRepository),
         updateLesson = UpdateLesson(tutorBillingRepository),
         deleteLesson = DeleteLesson(lessonDao),
-        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
     )
 
     @Test
@@ -119,6 +123,8 @@ class HomeMenuViewModelTest {
         override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
         override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {}
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {}
+        override fun isLessonInvoiced(lessonId: Long): Flow<Boolean?> = flow.map { list -> list.find { it.id == lessonId }?.isInvoiced }
         override fun getLessonsWithStudents(): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudent(studentId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String): Flow<List<LessonWithStudent>> = flowOf(emptyList())

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreenTest.kt
@@ -47,7 +47,9 @@ class LessonsScreenTest {
         addLesson = AddLesson(TutorBillingRepository(FakeStudentDao(), lessonDao)),
         updateLesson = UpdateLesson(TutorBillingRepository(FakeStudentDao(), lessonDao)),
         deleteLesson = DeleteLesson(lessonDao),
-        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
     )
 
     @Test
@@ -61,7 +63,7 @@ class LessonsScreenTest {
         )
         val vm = LessonsViewModel(lessonUseCases)
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> }, onAddLesson = {}, viewModel = vm)
+            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         val header1 = composeRule.onNodeWithTag("header_1").fetchSemanticsNode().positionInRoot.y
@@ -79,7 +81,7 @@ class LessonsScreenTest {
         val vm = LessonsViewModel(lessonUseCases)
         var clicked = false
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> clicked = true }, onAddLesson = {}, viewModel = vm)
+            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("10:00 • 60 min").performClick()
@@ -118,6 +120,12 @@ class LessonsScreenTest {
         override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
         override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {
             flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isPaid = paid)) else it }
+        }
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
+            flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isInvoiced = invoiced)) else it }
+        }
+        override fun isLessonInvoiced(lessonId: Long): Flow<Boolean?> = flow.map { list ->
+            list.find { it.lesson.id == lessonId }?.lesson?.isInvoiced
         }
         override fun getLessonsWithStudents(): Flow<List<LessonWithStudent>> = flow.asStateFlow()
         override fun getLessonsWithStudentsByStudent(studentId: Long): Flow<List<LessonWithStudent>> = flow.map { list -> list.filter { it.student.id == studentId } }

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
@@ -43,7 +43,9 @@ class LessonsViewModelTest {
         addLesson = AddLesson(repository),
         updateLesson = UpdateLesson(repository),
         deleteLesson = DeleteLesson(lessonDao),
-        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
     )
 
     @Test
@@ -65,6 +67,40 @@ class LessonsViewModelTest {
         assertEquals(listOf(1L, 2L), map.keys.toList())
         assertEquals(2, map[1L]?.size)
         assertEquals(1, map[2L]?.size)
+    }
+
+    @Test
+    fun updatePaidShowsGenerateInvoiceForUninvoicedLesson() = runTest {
+        val student = Student(id = 1, name = "Alice", surname = "A", parentMobile = "", className = "", rate = 10.0)
+        val today = LocalDate.now().toString()
+        lessonFlow.value = listOf(
+            LessonWithStudent(Lesson(1, 1, today, "10:00", 60), student)
+        )
+
+        val vm = LessonsViewModel(lessonUseCases)
+        advanceUntilIdle()
+
+        vm.updatePaid(1, true)
+        advanceUntilIdle()
+
+        assertEquals(LessonDialog.GenerateInvoice(1, 1), vm.uiState.value.dialog)
+    }
+
+    @Test
+    fun updatePaidShowsAlreadyInvoicedDialogWhenLessonInvoiced() = runTest {
+        val student = Student(id = 1, name = "Alice", surname = "A", parentMobile = "", className = "", rate = 10.0)
+        val today = LocalDate.now().toString()
+        lessonFlow.value = listOf(
+            LessonWithStudent(Lesson(1, 1, today, "10:00", 60, isInvoiced = true), student)
+        )
+
+        val vm = LessonsViewModel(lessonUseCases)
+        advanceUntilIdle()
+
+        vm.updatePaid(1, true)
+        advanceUntilIdle()
+
+        assertEquals(LessonDialog.AlreadyInvoiced(1, true), vm.uiState.value.dialog)
     }
 
     class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
@@ -95,6 +131,12 @@ class LessonsViewModelTest {
         override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
         override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {
             flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isPaid = paid)) else it }
+        }
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
+            flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isInvoiced = invoiced)) else it }
+        }
+        override fun isLessonInvoiced(lessonId: Long): Flow<Boolean?> = flow.map { list ->
+            list.find { it.lesson.id == lessonId }?.lesson?.isInvoiced
         }
         override fun getLessonsWithStudents(): Flow<List<LessonWithStudent>> = flow.asStateFlow()
         override fun getLessonsWithStudentsByStudent(studentId: Long): Flow<List<LessonWithStudent>> = flow.map { list -> list.filter { it.student.id == studentId } }

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/revenue/RevenueViewModelTest.kt
@@ -16,6 +16,8 @@ import gr.tsambala.tutorbilling.domain.lesson.AddLesson
 import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLesson
 import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonPaidStatus
+import gr.tsambala.tutorbilling.domain.lesson.UpdateLessonInvoicedStatus
+import gr.tsambala.tutorbilling.domain.lesson.IsLessonInvoiced
 import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
 import gr.tsambala.tutorbilling.domain.student.StudentUseCases
 import gr.tsambala.tutorbilling.domain.student.GetActiveStudents
@@ -75,7 +77,9 @@ class RevenueViewModelTest {
         addLesson = AddLesson(tutorBillingRepository),
         updateLesson = UpdateLesson(tutorBillingRepository),
         deleteLesson = DeleteLesson(lessonDao),
-        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao)
+        updateLessonPaidStatus = UpdateLessonPaidStatus(lessonDao),
+        updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
+        isLessonInvoiced = IsLessonInvoiced(lessonDao)
     )
 
     @Test
@@ -134,6 +138,12 @@ class RevenueViewModelTest {
         override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String): Flow<List<Lesson>> = flowOf(emptyList())
         override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {
             flow.value = flow.value.map { if (it.id in ids) it.copy(isPaid = paid) else it }
+        }
+        override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
+            flow.value = flow.value.map { if (it.id in ids) it.copy(isInvoiced = invoiced) else it }
+        }
+        override fun isLessonInvoiced(lessonId: Long): Flow<Boolean?> = flow.map { list ->
+            list.find { it.id == lessonId }?.isInvoiced
         }
         override fun getLessonsWithStudents(): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudent(studentId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())


### PR DESCRIPTION
- reintroduced updatePaid dialog checks
- adjusted fake DAOs and ViewModel state
- updated CHANGELOG

`./gradlew test` *(fails: MavenArtifactFetcher)*
`./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_687d8c5071508330b7e5e47c3f9804d5