### PR TITLE
refactor(lessons): use list in LessonsUiState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Replace bar chart drawable with `Icons.Default.BarChart` for Revenue FAB.
 - Add student domain tests for insert/update and archive/restore flows.
 - Add rebuild walkthrough in `rebuild.md` describing detailed steps.
+- Simplify LessonsUiState.lessons to a list and group in the screen.
 - Group lessons by student in Lessons screen with headers.
 - Add context menu actions to delete or archive past invoices.
 - Add domain and data modules for clean architecture foundation.

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreen.kt
@@ -70,12 +70,17 @@ fun LessonsScreen(
                 Text(text = stringResource(R.string.no_lessons))
             }
         } else {
+            val grouped = uiState.lessons
+                .groupBy { it.student.id }
+                .toList()
+                .sortedBy { (_, lessons) -> lessons.first().student.getFullName() }
+
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
             ) {
-                uiState.lessons.forEach { (studentId, lessons) ->
+                grouped.forEach { (studentId, lessons) ->
                     val studentName = lessons.first().student.getFullName()
                     item {
                         Card(

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModel.kt
@@ -25,12 +25,8 @@ class LessonsViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             lessonUseCases.getLessonsWithStudents().collect { list ->
-                val grouped = list
-                    .groupBy { it.student.id }
-                    .toList()
-                    .sortedBy { (_, lessons) -> lessons.first().student.getFullName() }
-                    .associate { it.first to it.second }
-                _uiState.update { it.copy(lessons = grouped) }
+                val sorted = list.sortedBy { it.student.getFullName() }
+                _uiState.update { it.copy(lessons = sorted) }
             }
         }
     }
@@ -38,7 +34,7 @@ class LessonsViewModel @Inject constructor(
     fun updatePaid(lessonId: Long, paid: Boolean) {
         viewModelScope.launch {
             val invoiced = lessonUseCases.isLessonInvoiced(lessonId).first() ?: false
-            val lesson = _uiState.value.lessons.values.flatten().find { it.lesson.id == lessonId }
+            val lesson = _uiState.value.lessons.find { it.lesson.id == lessonId }
             if (invoiced) {
                 _uiState.update { it.copy(dialog = LessonDialog.AlreadyInvoiced(lessonId, paid)) }
             } else if (paid && lesson != null) {
@@ -60,7 +56,7 @@ class LessonsViewModel @Inject constructor(
 }
 
 data class LessonsUiState(
-    val lessons: Map<Long, List<LessonWithStudent>> = emptyMap(),
+    val lessons: List<LessonWithStudent> = emptyList(),
     val dialog: LessonDialog? = null
 )
 

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsScreenTest.kt
@@ -89,7 +89,7 @@ class LessonsScreenTest {
         assertTrue(clicked)
         composeRule.onAllNodes(isToggleable())[0].performClick()
         advanceUntilIdle()
-        assertTrue(vm.uiState.value.lessons[1L]!!.first().lesson.isPaid)
+        assertTrue(vm.uiState.value.lessons.first().lesson.isPaid)
     }
 
     class FakeStudentDao : StudentDao {

--- a/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/tsambala/tutorbilling/ui/lessons/LessonsViewModelTest.kt
@@ -49,24 +49,21 @@ class LessonsViewModelTest {
     )
 
     @Test
-    fun groupsLessonsByStudentId() = runTest {
+    fun sortsLessonsByStudentName() = runTest {
         val s1 = Student(id = 1, name = "Alice", surname = "A", parentMobile = "", className = "", rate = 10.0)
         val s2 = Student(id = 2, name = "Bob", surname = "B", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 1, today, "10:00", 60, null, false), s1),
-            LessonWithStudent(Lesson(2, 2, today, "11:00", 60, null, false), s2),
-            LessonWithStudent(Lesson(3, 1, today, "09:00", 60, null, true), s1)
+            LessonWithStudent(Lesson(1, 2, today, "10:00", 60, null, false), s2),
+            LessonWithStudent(Lesson(2, 1, today, "11:00", 60, null, false), s1)
         )
 
         val vm = LessonsViewModel(lessonUseCases)
         advanceUntilIdle()
 
-        val map = vm.uiState.value.lessons
-        assertEquals(2, map.size)
-        assertEquals(listOf(1L, 2L), map.keys.toList())
-        assertEquals(2, map[1L]?.size)
-        assertEquals(1, map[2L]?.size)
+        val list = vm.uiState.value.lessons
+        assertEquals(2, list.size)
+        assertEquals(listOf(s1.id, s2.id), list.map { it.student.id })
     }
 
     @Test


### PR DESCRIPTION
- switch LessonsUiState.lessons back to List<LessonWithStudent>
- sort lessons by student name in ViewModel
- group lessons in LessonsScreen instead of ViewModel
- adjust tests for new data type

`./gradlew assemble` succeeded but `./gradlew test` failed due to network restrictions.


------
https://chatgpt.com/codex/tasks/task_e_687d938b00cc8330be634501646cd244