### PR TITLE
fix(student): validate parent mobile digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Align Settings screen styling with Revenue screen for consistent Material 3 design.
 - Redesign Settings screen with dropdown menus and colourful cards matching Revenue metrics.
 - Apply `primaryContainer` colors to remaining screens' top app bars.
+- Refine parent's mobile validation to require digits only.
 
 ## [0.14] - 2025-06-15
 ### Added

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -403,7 +403,8 @@ private fun StudentEditForm(
         )
 
         val mobileError = uiState.parentMobile.isNotBlank() &&
-            uiState.parentMobile.length != 10
+            (uiState.parentMobile.length != 10 ||
+                uiState.parentMobile.any { !it.isDigit() })
         OutlinedTextField(
             value = uiState.parentMobile,
             onValueChange = viewModel::updateParentMobile,


### PR DESCRIPTION
- WHAT changed
  - tightened parent's mobile validation to require 10 digits
  - documented change in CHANGELOG
- WHY it matters
  - ensures only numeric phone numbers are allowed when optional
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_687e146c7708833098fb16ab4aa18935