### PR TITLE
docs: add per-PR versioning guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Run these *exact* commands before proposing code changes:
 ```
 
 Checklist:
-* [ ] `CHANGELOG.md` updated
+* [ ] Version bumped and `CHANGELOG.md` updated
 
 * [ ] Unit tests passing
 * [ ] Lint shows **0** new warnings
@@ -81,7 +81,7 @@ Checklist:
 5. **Robolectric memory leaks** – never keep global state in test classes; use `@Config` with `sdk = 34`.
 
 ## 8. Changelog
-Update `CHANGELOG.md` under the repository root with a bullet for each pull request under the **Unreleased** section.
+Update `CHANGELOG.md` under the repository root with a bullet for each pull request under the **Unreleased** section and bump the version before merging.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Introduce per-pull-request version bump policy; each PR increments the project version.
 - Ensure date and time fields in Lesson screen open the appropriate picker when tapped.
 - Flatten Room migrations; keep only latest schema in data/schemas.
 - Replace bar chart drawable with `Icons.Default.BarChart` for Revenue FAB.

--- a/README.md
+++ b/README.md
@@ -65,4 +65,7 @@ When you modify an entity schema:
 
 ## Changelog
 
-A high level summary of changes lives in [`CHANGELOG.md`](CHANGELOG.md). Update the **Unreleased** section with a bullet point when opening a pull request.
+A high level summary of changes lives in [`CHANGELOG.md`](CHANGELOG.md).
+This project is still unreleased, so each pull request should bump the
+version to the next `0.x` value before merge and add a bullet to the
+**Unreleased** section describing the change.


### PR DESCRIPTION
## Summary
- clarify in README that each pull request should bump the version to the next `0.x`
- require version bump in AGENTS instructions
- note new policy in CHANGELOG

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_687e1684b9708330ad76d1fcb6ce672c