### PR TITLE
feat(build): update google services and crashlytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- Bump version to 0.7 and integrate latest Google Services plugin and Crashlytics library.
+
 ## [0.15] - 2025-07-21
 ### Added
 - Introduce per-pull-request version bump policy; each PR increments the project version.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "gr.tsambala.tutorbilling"
         minSdk 26
         targetSdk 35
-        versionCode 5
-        versionName "0.6"
+        versionCode 6
+        versionName "0.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -137,6 +137,7 @@ android {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
     implementation platform('com.google.firebase:firebase-bom:33.15.0')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-crashlytics:19.4.4'
 }
 
 // Room schema location for ksp

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.1.10-1.0.30'
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.54'
         classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.1.10'
-        classpath 'com.google.gms:google-services:4.4.2'
+        classpath 'com.google.gms:google-services:4.4.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.4'
     }
 }


### PR DESCRIPTION
- WHAT changed
  - updated google-services plugin version and added Crashlytics library
  - bumped app version to 0.7 and noted changes in CHANGELOG
- WHY it matters
  - keeps dependencies current and records version bump per PR policy
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_687e1fd6cdac8330999589695c7bc5d9