### PR TITLE
docs: document version 0.16 and per-PR bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Run these *exact* commands before proposing code changes:
 | `/data/schemas`                | Room JSON schemas (auto-generated; keep under VC) |
 | `build/`, `.gradle/`, `.idea/` | **Ignored** – see `.gitignore`                         |
 | `local.properties`             | **Ignored** – SDK path, never commit                   |
-| `CHANGELOG.md`                 | Project changelog; update the Unreleased section |
+| `CHANGELOG.md`                 | Project changelog; start a new versioned section for each pull request |
 
 ## 6. Pull-Request Messaging Template
 
@@ -65,7 +65,7 @@ Run these *exact* commands before proposing code changes:
 ```
 
 Checklist:
-* [ ] `CHANGELOG.md` updated
+* [ ] Version bumped and `CHANGELOG.md` updated
 
 * [ ] Unit tests passing
 * [ ] Lint shows **0** new warnings
@@ -81,7 +81,7 @@ Checklist:
 5. **Robolectric memory leaks** – never keep global state in test classes; use `@Config` with `sdk = 34`.
 
 ## 8. Changelog
-Update `CHANGELOG.md` under the repository root with a bullet for each pull request under the **Unreleased** section.
+Update `CHANGELOG.md` by creating a new `[0.x]` section dated for your pull request. Bump `versionName` in `app/build.gradle` to match (current version is `0.16`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,35 +3,41 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- Ensure date and time fields in Lesson screen open the appropriate picker when tapped.
-- Flatten Room migrations; keep only latest schema in data/schemas.
-- Replace bar chart drawable with `Icons.Default.BarChart` for Revenue FAB.
+
+## [0.16] - 2025-07-21
+### Added
+- Introduce per-pull-request version bump policy; each PR increments the project version.
 - Add student domain tests for insert/update and archive/restore flows.
 - Add rebuild walkthrough in `rebuild.md` describing detailed steps.
-- Simplify LessonsUiState.lessons to a list and group in the screen.
 - Group lessons by student in Lessons screen with headers.
 - Add context menu actions to delete or archive past invoices.
 - Add domain and data modules for clean architecture foundation.
 - Add AddLesson/GetStudentLessons use-cases and Room DAO tests.
-- Move Room and repository code into `data` module and business utilities into `domain`.
 - Reintroduce LessonsViewModel.updatePaid tests for invoicing prompts.
-- Track invoicing state on lessons and prompt when toggling paid status.
-- Fix launcher icon references in the AndroidManifest.
 - Add CI workflow to run clean, assemble, test and lint on every push.
-- Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.
-- Show student surname in all UI lists using `getFullName()` extension.
-- Make release signingConfig conditional on keystore properties.
 - Integrate Firebase Crashlytics for runtime crash reporting.
-- Allow saving students without a phone number and warn if no contact details are provided.
-- Removed Google Sign-In feature and account persistence.
-- Show Classes button highlighted when a valid class exists.
 - In-app privacy policy screen linked from Settings.
 - Provide Hilt modules for DAOs and repositories.
 - Expose domain use-cases and inject them into ViewModels.
 - Provide offline Robolectric artifacts and a coroutine MainDispatcherRule for tests.
+- Document modules overview in README.
+
+### Changed
+- Ensure date and time fields in Lesson screen open the appropriate picker when tapped.
+- Flatten Room migrations; keep only latest schema in data/schemas.
+- Replace bar chart drawable with `Icons.Default.BarChart` for Revenue FAB.
+- Simplify LessonsUiState.lessons to a list and group in the screen.
+- Move Room and repository code into `data` module and business utilities into `domain`.
+- Track invoicing state on lessons and prompt when toggling paid status.
+- Fix launcher icon references in the AndroidManifest.
+- Upgrade to Android Gradle Plugin 8.8.0 and Gradle 8.10.2.
+- Show student surname in all UI lists using `getFullName()` extension.
+- Make release signingConfig conditional on keystore properties.
+- Allow saving students without a phone number and warn if no contact details are provided.
+- Removed Google Sign-In feature and account persistence.
+- Show Classes button highlighted when a valid class exists.
 - Split large Compose screens and add design system shapes.
 - Reinstate Room auto-migrations up to version 9.
-- Document modules overview in README.
 - Refresh README with build commands and module layout after rebuild.
 - Relax phone validation when saving students; accept any non-blank value.
 - Align Settings screen styling with Revenue screen for consistent Material 3 design.

--- a/README.md
+++ b/README.md
@@ -65,4 +65,7 @@ When you modify an entity schema:
 
 ## Changelog
 
-A high level summary of changes lives in [`CHANGELOG.md`](CHANGELOG.md). Update the **Unreleased** section with a bullet point when opening a pull request.
+A high level summary of changes lives in [`CHANGELOG.md`](CHANGELOG.md).
+This project is still unreleased and currently version `0.16`. Each
+pull request should bump the version to the next `0.x` value and add a
+changelog entry before merge.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "gr.tsambala.tutorbilling"
         minSdk 26
         targetSdk 35
-        versionCode 5
-        versionName "0.6"
+        versionCode 16
+        versionName "0.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/rebuild.md
+++ b/rebuild.md
@@ -79,7 +79,7 @@ All tests and lint checks must pass before committing.
 
 1. Update `README.md` to reflect the new module layout and the build commands above.
 2. Document any additional project rules in `AGENTS.md` if required.
-3. Mention this rebuild guide in `CHANGELOG.md` under the **Unreleased** section.
+3. Mention this rebuild guide in `CHANGELOG.md` under the appropriate version entry.
 
 ## 9. Final verification
 


### PR DESCRIPTION
## Summary
- move unreleased notes to 0.16 entry
- describe version bump policy in README and AGENTS guidance
- update rebuild instructions for versioned changelog entries
- bump app version to 0.16

## Testing
- `./gradlew clean`
- `./gradlew assemble` *(timeout)*
- `./gradlew test` *(timeout)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_687e1684b9708330ad76d1fcb6ce672c