### PR TITLE
fix(lesson): make date/time fields clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18] - 2025-07-23
+### Changed
+- Date and time fields in Lesson screen are now directly clickable to open their pickers.
+
 ## [0.17] - 2025-07-22
 ### Changed
 - Unified theme utilities and replaced per-screen colors.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 16
-        versionName "0.17"
+        versionName "0.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -139,22 +139,15 @@ fun LessonScreen(
             val datePickerState = rememberDatePickerState(
                 initialSelectedDateMillis = currentDate.atStartOfDay(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli()
             )
-            Box(modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    Log.d("LessonScreen", "Date box clicked -> showDatePicker from $showDatePicker to true")
+            ClickableReadOnlyField(
+                value = uiState.date,
+                onClick = {
+                    Log.d("LessonScreen", "Date field clicked -> showDatePicker from $showDatePicker to true")
                     showDatePicker = true
-                }) {
-                ClickableReadOnlyField(
-                    value = uiState.date,
-                    onClick = {
-                        Log.d("LessonScreen", "Date field clicked -> showDatePicker from $showDatePicker to true")
-                        showDatePicker = true
-                    },
-                    label = { Text("Date") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+                },
+                label = { Text("Date") },
+                modifier = Modifier.fillMaxWidth()
+            )
             if (showDatePicker) {
                 DatePickerDialog(
                     onDismissRequest = { showDatePicker = false },
@@ -185,22 +178,15 @@ fun LessonScreen(
             val (startHour, startMinute) = uiState.startTime.split(":").mapNotNull { it.toIntOrNull() }
                 .let { if (it.size == 2) it[0] to it[1] else LocalTime.now().hour to LocalTime.now().minute }
             val timePickerState = rememberTimePickerState(startHour, startMinute, true)
-            Box(modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    Log.d("LessonScreen", "Time box clicked -> showTimePicker from $showTimePicker to true")
+            ClickableReadOnlyField(
+                value = uiState.startTime,
+                onClick = {
+                    Log.d("LessonScreen", "Time field clicked -> showTimePicker from $showTimePicker to true")
                     showTimePicker = true
-                }) {
-                ClickableReadOnlyField(
-                    value = uiState.startTime,
-                    onClick = {
-                        Log.d("LessonScreen", "Time field clicked -> showTimePicker from $showTimePicker to true")
-                        showTimePicker = true
-                    },
-                    label = { Text("Start Time") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+                },
+                label = { Text("Start Time") },
+                modifier = Modifier.fillMaxWidth()
+            )
             if (showTimePicker) {
                 AlertDialog(
                     onDismissRequest = { showTimePicker = false },

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -30,6 +30,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.tsambala.tutorbilling.data.model.RateTypes
 import gr.tsambala.tutorbilling.data.model.Lesson
 import gr.tsambala.tutorbilling.utils.ClassOptions
+import gr.tsambala.tutorbilling.ui.design.AppTopBar
+import gr.tsambala.tutorbilling.ui.design.Dimensions
+import gr.tsambala.tutorbilling.ui.design.AppColors
+import gr.tsambala.tutorbilling.ui.design.MetricCard
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 


### PR DESCRIPTION
- remove Box wrappers from Lesson date/time fields
- call `ClickableReadOnlyField` with `fillMaxWidth()`
- import design system components in StudentScreen
- bump version to 0.18

`./gradlew lintDebug` and `assemble` pass, but unit tests failed due to network fetch errors.

------
https://chatgpt.com/codex/tasks/task_e_687e5228a37c83308a8c8174ef0e7a90