### PR TITLE
fix(ui): avoid double pop on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19] - 2025-07-24
+### Fixed
+- Prevent double navigation when saving new students or lessons.
+- Display full student name in headers without extra spaces.
+
 ## [0.18] - 2025-07-23
 ### Changed
 - Date and time fields in Lesson screen are now directly clickable to open their pickers.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "gr.tsambala.tutorbilling"
         minSdk 26
         targetSdk 35
-        versionCode 16
-        versionName "0.18"
+        versionCode 17
+        versionName "0.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -290,9 +290,6 @@ fun LessonScreen(
                 Button(
                     onClick = {
                         viewModel.saveLesson()
-                        if (lessonId == 0L) {
-                            onNavigateBack()
-                        }
                     },
                     modifier = Modifier.weight(1f),
                     enabled = viewModel.isFormValid()

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/student/StudentScreen.kt
@@ -56,7 +56,7 @@ fun StudentScreen(
                 title = when {
                     uiState.isEditMode && viewModel.studentId == 0L -> "Add Student"
                     uiState.isEditMode -> "Edit Student"
-                    else -> uiState.name
+                    else -> "${uiState.name} ${uiState.surname}".trim()
                 },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
@@ -89,9 +89,6 @@ fun StudentScreen(
                 viewModel = viewModel,
                 onSave = {
                     viewModel.saveStudent()
-                    if (viewModel.studentId == 0L) {
-                        onNavigateBack()
-                    }
                 },
                 onCancel = {
                     if (viewModel.studentId == 0L) {
@@ -188,7 +185,7 @@ private fun StudentDetailView(
                     modifier = Modifier.padding(Dimensions.PaddingMedium)
                 ) {
                     Text(
-                        text = uiState.name,
+                        text = "${uiState.name} ${uiState.surname}".trim(),
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold
                     )


### PR DESCRIPTION
- Removed extra navigation when saving lessons or students
- Trimmed student name display and updated headers
- Bumped version to 0.19

How to test:
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687e5c8299f883309185f7b9b0b3c815