### PR TITLE
feat(data): add student group entities and dao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20] - 2025-07-25
+### Added
+- Student group tables and DAO with repository and DI modules.
+- Auto-migration to database version 11.
+
 ## [0.19] - 2025-07-24
 ### Fixed
 - Prevent double navigation when saving new students or lessons.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 17
-        versionName "0.19"
+        versionName "0.20"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/dao/GroupDao.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/dao/GroupDao.kt
@@ -1,0 +1,41 @@
+package gr.tsambala.tutorbilling.data.dao
+
+import androidx.room.*
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface GroupDao {
+    // StudentGroup CRUD
+    @Insert
+    suspend fun insertGroup(group: StudentGroup): Long
+
+    @Update
+    suspend fun updateGroup(group: StudentGroup)
+
+    @Delete
+    suspend fun deleteGroup(group: StudentGroup)
+
+    @Query("SELECT * FROM ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUPS_TABLE} ORDER BY name ASC")
+    fun getAllGroups(): Flow<List<StudentGroup>>
+
+    @Query("SELECT * FROM ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUPS_TABLE} WHERE id = :id")
+    fun getGroupById(id: Long): Flow<StudentGroup?>
+
+    // Cross-ref operations
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCrossRef(crossRef: GroupStudentCrossRef)
+
+    @Query(
+        "DELETE FROM ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE} WHERE groupId = :groupId AND studentId = :studentId"
+    )
+    suspend fun deleteCrossRef(groupId: Long, studentId: Long)
+
+    @Transaction
+    @Query(
+        "SELECT students.* FROM students INNER JOIN ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE} ON students.id = ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE}.studentId WHERE ${gr.tsambala.tutorbilling.data.database.DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE}.groupId = :groupId"
+    )
+    fun getStudentsForGroup(groupId: Long): Flow<List<Student>>
+}

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/database/DatabaseConstants.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/database/DatabaseConstants.kt
@@ -4,4 +4,6 @@ object DatabaseConstants {
     const val DATABASE_NAME = "tutor_billing_database"
     const val STUDENTS_TABLE = "students"
     const val LESSONS_TABLE = "lessons"
+    const val GROUPS_TABLE = "student_groups"
+    const val GROUP_STUDENT_CROSS_REF_TABLE = "group_student_cross_ref"
 }

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/database/TutorBillingDatabase.kt
@@ -6,26 +6,31 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import gr.tsambala.tutorbilling.data.dao.GroupDao
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
 import gr.tsambala.tutorbilling.data.model.Lesson
 import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentGroup
 
 @Database(
-    entities = [Student::class, Lesson::class],
-    version = 10, // Current version
+    entities = [Student::class, Lesson::class, StudentGroup::class, GroupStudentCrossRef::class],
+    version = 11, // Current version
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
-        AutoMigration(from = 9, to = 10)
+        AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 10, to = 11)
     ]
 )
 abstract class TutorBillingDatabase : RoomDatabase() {
     abstract fun studentDao(): StudentDao
     abstract fun lessonDao(): LessonDao
+    abstract fun groupDao(): GroupDao
 
     companion object {
         @Volatile

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/di/DaoModule.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/di/DaoModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.GroupDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
 import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
 
@@ -16,4 +17,7 @@ object DaoModule {
 
     @Provides
     fun provideLessonDao(db: TutorBillingDatabase): LessonDao = db.lessonDao()
+
+    @Provides
+    fun provideGroupDao(db: TutorBillingDatabase): GroupDao = db.groupDao()
 }

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/di/RepositoryModule.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/di/RepositoryModule.kt
@@ -5,9 +5,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import gr.tsambala.tutorbilling.data.dao.LessonDao
+import gr.tsambala.tutorbilling.data.dao.GroupDao
 import gr.tsambala.tutorbilling.data.dao.StudentDao
 import gr.tsambala.tutorbilling.data.repository.StudentRepository
 import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
 import javax.inject.Singleton
 
 @Module
@@ -17,6 +19,11 @@ object RepositoryModule {
     @Singleton
     fun provideStudentRepository(studentDao: StudentDao): StudentRepository =
         StudentRepository(studentDao)
+
+    @Provides
+    @Singleton
+    fun provideGroupRepository(groupDao: GroupDao): GroupRepository =
+        GroupRepository(groupDao)
 
     @Provides
     @Singleton

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/model/GroupStudentCrossRef.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/model/GroupStudentCrossRef.kt
@@ -1,0 +1,15 @@
+package gr.tsambala.tutorbilling.data.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import gr.tsambala.tutorbilling.data.database.DatabaseConstants
+
+@Entity(
+    tableName = DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE,
+    primaryKeys = ["groupId", "studentId"],
+    indices = [Index(value = ["studentId"]), Index(value = ["groupId"])]
+)
+data class GroupStudentCrossRef(
+    val groupId: Long,
+    val studentId: Long
+)

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/model/StudentGroup.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/model/StudentGroup.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.data.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import gr.tsambala.tutorbilling.data.database.DatabaseConstants
+
+@Entity(tableName = DatabaseConstants.GROUPS_TABLE)
+data class StudentGroup(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val name: String
+)

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/repository/GroupRepository.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/repository/GroupRepository.kt
@@ -1,0 +1,23 @@
+package gr.tsambala.tutorbilling.data.repository
+
+import gr.tsambala.tutorbilling.data.dao.GroupDao
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GroupRepository @Inject constructor(
+    private val dao: GroupDao
+) {
+    suspend fun insertGroup(group: StudentGroup): Long = dao.insertGroup(group)
+    suspend fun updateGroup(group: StudentGroup) = dao.updateGroup(group)
+    suspend fun deleteGroup(group: StudentGroup) = dao.deleteGroup(group)
+    fun getAllGroups(): Flow<List<StudentGroup>> = dao.getAllGroups()
+    fun getGroupById(id: Long): Flow<StudentGroup?> = dao.getGroupById(id)
+    suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) = dao.insertCrossRef(crossRef)
+    suspend fun deleteCrossRef(groupId: Long, studentId: Long) = dao.deleteCrossRef(groupId, studentId)
+    fun getStudentsForGroup(groupId: Long): Flow<List<Student>> = dao.getStudentsForGroup(groupId)
+}

--- a/data/src/test/java/gr/tsambala/tutorbilling/data/GroupDaoTest.kt
+++ b/data/src/test/java/gr/tsambala/tutorbilling/data/GroupDaoTest.kt
@@ -1,0 +1,52 @@
+package gr.tsambala.tutorbilling.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.dao.GroupDao
+import gr.tsambala.tutorbilling.data.dao.StudentDao
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GroupDaoTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var groupDao: GroupDao
+    private lateinit var studentDao: StudentDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        groupDao = db.groupDao()
+        studentDao = db.studentDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertGroupAndStudents() = runBlocking {
+        val groupId = groupDao.insertGroup(StudentGroup(name = "Group A"))
+        val studentId = studentDao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        groupDao.insertCrossRef(GroupStudentCrossRef(groupId = groupId, studentId = studentId))
+        val students = groupDao.getStudentsForGroup(groupId).first()
+        assertEquals(1, students.size)
+        assertEquals(studentId, students.first().id)
+    }
+}


### PR DESCRIPTION
## Summary
- support grouping students by adding StudentGroup and GroupStudentCrossRef entities
- implement GroupDao with CRUD and cross-ref helpers
- expose GroupRepository via Hilt
- register group tables in TutorBillingDatabase with auto-migration to version 11
- bump app version to 0.20 and document changes

## Testing
- `./gradlew clean assemble test lintDebug` *(failed: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_687e620dbe70833099457faf40acfda6