### PR TITLE
feat(groups): add basic group management

### DIFF
--- a/app/src/main/java/gr/tsambala/tutorbilling/NavigationRoutes.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/NavigationRoutes.kt
@@ -21,4 +21,8 @@ sealed class Screen(val route: String) {
     object Settings : Screen("settings")
     object PrivacyPolicy : Screen("privacyPolicy")
     object ArchivedStudents : Screen("archivedStudents")
+    object Groups : Screen("groups")
+    object Group : Screen("group/{groupId}") {
+        fun createRoute(groupId: Long) = "group/$groupId"
+    }
 }

--- a/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/TutorBillingApp.kt
@@ -35,6 +35,7 @@ fun TutorBillingApp() {
                 onNavigateToStudent = { navController.navigate(Screen.Students.route) },
                 onClassesClick = { navController.navigate(Screen.Classes.route) },
                 onNavigateToLesson = { navController.navigate(Screen.Lessons.route) },
+                onNavigateToGroups = { navController.navigate(Screen.Groups.route) },
                 onNavigateToNewStudent = { navController.navigate(Screen.Student.createRoute(0)) },
                 onNavigateToNewLesson = { navController.navigate(Screen.Lesson.createRoute(0)) },
                 onRevenue = { navController.navigate(Screen.Revenue.route) },
@@ -43,6 +44,21 @@ fun TutorBillingApp() {
         }
 
         studentGraph(navController)
+
+        composable(Screen.Groups.route) {
+            GroupsScreen(
+                onBack = { navController.popBackStack() },
+                onGroupClick = { id -> navController.navigate(Screen.Group.createRoute(id)) },
+                onAddGroup = { navController.navigate(Screen.Group.createRoute(0)) }
+            )
+        }
+
+        composable(
+            route = Screen.Group.route,
+            arguments = listOf(navArgument("groupId") { type = NavType.LongType })
+        ) { backStackEntry ->
+            GroupScreen(onBack = { navController.popBackStack() })
+        }
 
         // Classes list screen
         composable(Screen.Classes.route) {

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupScreen.kt
@@ -1,0 +1,71 @@
+package gr.tsambala.tutorbilling.ui.groups
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.*
+import gr.tsambala.tutorbilling.ui.design.AppTopBar
+import gr.tsambala.tutorbilling.ui.design.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupScreen(
+    onBack: () -> Unit,
+    viewModel: GroupViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = if (viewModel.groupId == 0L) "Add Group" else "Edit Group",
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { viewModel.saveGroup(); onBack() }) {
+                        Text("Save")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(Dimensions.PaddingMedium),
+            verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
+        ) {
+            OutlinedTextField(
+                value = uiState.name,
+                onValueChange = viewModel::updateName,
+                label = { Text("Group Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Text(text = "Students", style = MaterialTheme.typography.titleMedium)
+            LazyColumn {
+                items(uiState.students) { item ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Checkbox(
+                            checked = item.selected,
+                            onCheckedChange = { viewModel.toggleStudent(item.id) }
+                        )
+                        Text(text = item.name)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupViewModel.kt
@@ -1,0 +1,79 @@
+package gr.tsambala.tutorbilling.ui.groups
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import gr.tsambala.tutorbilling.domain.group.GroupUseCases
+import gr.tsambala.tutorbilling.domain.student.StudentUseCases
+import gr.tsambala.tutorbilling.data.model.Student
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupViewModel @Inject constructor(
+    private val groupUseCases: GroupUseCases,
+    private val studentUseCases: StudentUseCases,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    val groupId: Long = savedStateHandle.get<Long>("groupId") ?: 0L
+
+    private val _uiState = MutableStateFlow(GroupUiState())
+    val uiState: StateFlow<GroupUiState> = _uiState.asStateFlow()
+
+    private var originalStudents: Set<Long> = emptySet()
+
+    init {
+        viewModelScope.launch {
+            val students = studentUseCases.getActiveStudents().first()
+            val selectedIds = if (groupId != 0L) {
+                groupUseCases.getGroupStudents(groupId).first().map { it.id }.toSet()
+            } else emptySet()
+            originalStudents = selectedIds
+            val selections = students.map { StudentSelection(it.id, it.name, it.surname, it.id in selectedIds) }
+            val name = if (groupId != 0L) groupUseCases.getGroupById(groupId).first()?.name ?: "" else ""
+            _uiState.value = GroupUiState(name = name, students = selections)
+        }
+    }
+
+    fun updateName(value: String) {
+        _uiState.value = _uiState.value.copy(name = value)
+    }
+
+    fun toggleStudent(id: Long) {
+        _uiState.value = _uiState.value.copy(
+            students = _uiState.value.students.map {
+                if (it.id == id) it.copy(selected = !it.selected) else it
+            }
+        )
+    }
+
+    fun saveGroup() {
+        viewModelScope.launch {
+            val state = _uiState.value
+            val group = StudentGroup(id = groupId, name = state.name)
+            val id = if (groupId == 0L) groupUseCases.insertGroup(group) else {
+                groupUseCases.updateGroup(group)
+                groupId
+            }
+
+            val selected = state.students.filter { it.selected }.map { it.id }.toSet()
+            val toAdd = selected - originalStudents
+            val toRemove = originalStudents - selected
+            toAdd.forEach { groupUseCases.addStudentToGroup(id, it) }
+            toRemove.forEach { groupUseCases.removeStudentFromGroup(id, it) }
+        }
+    }
+}
+
+data class StudentSelection(val id: Long, val name: String, val surname: String, val selected: Boolean)
+
+data class GroupUiState(
+    val name: String = "",
+    val students: List<StudentSelection> = emptyList()
+)

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupsScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupsScreen.kt
@@ -1,0 +1,62 @@
+package gr.tsambala.tutorbilling.ui.groups
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import gr.tsambala.tutorbilling.ui.design.AppTopBar
+import gr.tsambala.tutorbilling.ui.design.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupsScreen(
+    onBack: () -> Unit,
+    onGroupClick: (Long) -> Unit,
+    onAddGroup: () -> Unit,
+    viewModel: GroupsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = "Groups",
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddGroup) {
+                Icon(Icons.Default.Add, contentDescription = "Add Group")
+            }
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            items(uiState.groups) { group ->
+                Text(
+                    text = group.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onGroupClick(group.id) }
+                        .padding(Dimensions.PaddingMedium)
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupsViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/groups/GroupsViewModel.kt
@@ -1,0 +1,32 @@
+package gr.tsambala.tutorbilling.ui.groups
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.tsambala.tutorbilling.domain.group.GroupUseCases
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import androidx.lifecycle.viewModelScope
+import javax.inject.Inject
+
+@HiltViewModel
+class GroupsViewModel @Inject constructor(
+    groupUseCases: GroupUseCases
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(GroupsUiState())
+    val uiState: StateFlow<GroupsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            groupUseCases.getAllGroups().collect { groups ->
+                _uiState.value = GroupsUiState(groups)
+            }
+        }
+    }
+}
+
+data class GroupsUiState(
+    val groups: List<gr.tsambala.tutorbilling.data.model.StudentGroup> = emptyList()
+)

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/home/HomeMenuScreen.kt
@@ -26,6 +26,7 @@ import gr.tsambala.tutorbilling.R
 fun HomeMenuScreen(
     onNavigateToStudent: () -> Unit,
     onClassesClick: () -> Unit,
+    onNavigateToGroups: () -> Unit,
     onNavigateToLesson: () -> Unit,
     onNavigateToNewStudent: () -> Unit,
     onNavigateToNewLesson: () -> Unit,
@@ -119,6 +120,11 @@ fun HomeMenuScreen(
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = AppColors.secondaryContainer)
                 ) { Text("Classes") }
+                Button(
+                    onClick = onNavigateToGroups,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.secondaryContainer)
+                ) { Text("Groups") }
                 Button(
                     onClick = onNavigateToLesson,
                     modifier = Modifier.fillMaxWidth(),

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/dao/LessonDao.kt
@@ -54,6 +54,7 @@ interface LessonDao {
         """
         SELECT lessons.id AS lesson_id,
                lessons.studentId AS lesson_studentId,
+               lessons.groupId AS lesson_groupId,
                lessons.date AS lesson_date,
                lessons.startTime AS lesson_startTime,
                lessons.durationMinutes AS lesson_durationMinutes,
@@ -78,9 +79,10 @@ interface LessonDao {
     @Transaction
     @Query(
         """
-        SELECT lessons.id AS lesson_id,
-               lessons.studentId AS lesson_studentId,
-               lessons.date AS lesson_date,
+       SELECT lessons.id AS lesson_id,
+              lessons.studentId AS lesson_studentId,
+              lessons.groupId AS lesson_groupId,
+              lessons.date AS lesson_date,
                lessons.startTime AS lesson_startTime,
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
@@ -105,9 +107,10 @@ interface LessonDao {
     @Transaction
     @Query(
         """
-        SELECT lessons.id AS lesson_id,
-               lessons.studentId AS lesson_studentId,
-               lessons.date AS lesson_date,
+       SELECT lessons.id AS lesson_id,
+              lessons.studentId AS lesson_studentId,
+              lessons.groupId AS lesson_groupId,
+              lessons.date AS lesson_date,
                lessons.startTime AS lesson_startTime,
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,
@@ -132,9 +135,10 @@ interface LessonDao {
     @Transaction
     @Query(
         """
-        SELECT lessons.id AS lesson_id,
-               lessons.studentId AS lesson_studentId,
-               lessons.date AS lesson_date,
+       SELECT lessons.id AS lesson_id,
+              lessons.studentId AS lesson_studentId,
+              lessons.groupId AS lesson_groupId,
+              lessons.date AS lesson_date,
                lessons.startTime AS lesson_startTime,
                lessons.durationMinutes AS lesson_durationMinutes,
                lessons.notes AS lesson_notes,

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/di/RepositoryModule.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/di/RepositoryModule.kt
@@ -29,6 +29,7 @@ object RepositoryModule {
     @Singleton
     fun provideTutorBillingRepository(
         studentDao: StudentDao,
-        lessonDao: LessonDao
-    ): TutorBillingRepository = TutorBillingRepository(studentDao, lessonDao)
+        lessonDao: LessonDao,
+        groupDao: GroupDao
+    ): TutorBillingRepository = TutorBillingRepository(studentDao, lessonDao, groupDao)
 }

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/model/Lesson.kt
@@ -28,6 +28,8 @@ data class Lesson(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
     val studentId: Long,
+    @ColumnInfo(defaultValue = "NULL")
+    val groupId: Long? = null,
     val date: String, // Store as ISO date string (yyyy-MM-dd)
     val startTime: String, // Store as time string (HH:mm)
     val durationMinutes: Int,
@@ -44,6 +46,7 @@ data class Lesson(
     companion object {
         fun create(
             studentId: Long,
+            groupId: Long? = null,
             date: LocalDate,
             startTime: LocalTime,
             durationMinutes: Int,
@@ -53,6 +56,7 @@ data class Lesson(
         ): Lesson {
             return Lesson(
                 studentId = studentId,
+                groupId = groupId,
                 date = date.toString(),
                 startTime = startTime.toString(),
                 durationMinutes = durationMinutes,

--- a/data/src/main/java/gr/tsambala/tutorbilling/data/repository/TutorBillingRepository.kt
+++ b/data/src/main/java/gr/tsambala/tutorbilling/data/repository/TutorBillingRepository.kt
@@ -30,7 +30,8 @@ import javax.inject.Singleton
 @Singleton
 class TutorBillingRepository @Inject constructor(
     private val studentDao: StudentDao,
-    private val lessonDao: LessonDao
+    private val lessonDao: LessonDao,
+    private val groupDao: gr.tsambala.tutorbilling.data.dao.GroupDao
 ) {
 
     // ===== Student Operations =====
@@ -92,6 +93,19 @@ class TutorBillingRepository @Inject constructor(
         checkNotNull(student) { "Cannot add lesson for a non-existent student" }
         check(student.isActive) { "Cannot add lesson for an inactive student" }
         return lessonDao.insert(lesson)
+    }
+
+    suspend fun addGroupLesson(groupId: Long, lesson: Lesson): List<Long> {
+        require(lesson.durationMinutes > 0) { "Lesson duration must be positive" }
+        val students = groupDao.getStudentsForGroup(groupId).first()
+        return students.map { student ->
+            lessonDao.insert(
+                lesson.copy(
+                    studentId = student.id,
+                    groupId = groupId
+                )
+            )
+        }
     }
 
     /**

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/di/DomainModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import gr.tsambala.tutorbilling.data.dao.LessonDao
 import gr.tsambala.tutorbilling.data.repository.StudentRepository
 import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
 import gr.tsambala.tutorbilling.domain.lesson.*
 import gr.tsambala.tutorbilling.domain.student.*
 import javax.inject.Singleton
@@ -31,6 +32,20 @@ object DomainModule {
 
     @Provides
     @Singleton
+    fun provideGroupUseCases(repository: GroupRepository): GroupUseCases =
+        GroupUseCases(
+            insertGroup = InsertGroup(repository),
+            updateGroup = UpdateGroup(repository),
+            deleteGroup = DeleteGroup(repository),
+            getAllGroups = GetAllGroups(repository),
+            getGroupById = GetGroupById(repository),
+            addStudentToGroup = AddStudentToGroup(repository),
+            removeStudentFromGroup = RemoveStudentFromGroup(repository),
+            getGroupStudents = GetGroupStudents(repository)
+        )
+
+    @Provides
+    @Singleton
     fun provideLessonUseCases(
         dao: LessonDao,
         repository: TutorBillingRepository
@@ -42,6 +57,7 @@ object DomainModule {
             getLessonsWithStudents = GetLessonsWithStudents(dao),
             getLessonsWithStudentsByStudentAndDateRange = GetLessonsWithStudentsByStudentAndDateRange(dao),
             addLesson = AddLesson(repository),
+            addGroupLesson = AddGroupLesson(repository),
             updateLesson = UpdateLesson(repository),
             deleteLesson = DeleteLesson(dao),
             updateLessonPaidStatus = UpdateLessonPaidStatus(dao),

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/AddStudentToGroup.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/AddStudentToGroup.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
+import javax.inject.Inject
+
+class AddStudentToGroup @Inject constructor(
+    private val repository: GroupRepository
+) {
+    suspend operator fun invoke(groupId: Long, studentId: Long) =
+        repository.insertCrossRef(GroupStudentCrossRef(groupId, studentId))
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/DeleteGroup.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/DeleteGroup.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import javax.inject.Inject
+
+class DeleteGroup @Inject constructor(
+    private val repository: GroupRepository
+) {
+    suspend operator fun invoke(group: StudentGroup) = repository.deleteGroup(group)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetAllGroups.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetAllGroups.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAllGroups @Inject constructor(
+    private val repository: GroupRepository
+) {
+    operator fun invoke(): Flow<List<StudentGroup>> = repository.getAllGroups()
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetGroupById.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetGroupById.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetGroupById @Inject constructor(
+    private val repository: GroupRepository
+) {
+    operator fun invoke(id: Long): Flow<StudentGroup?> = repository.getGroupById(id)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetGroupStudents.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GetGroupStudents.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.Student
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetGroupStudents @Inject constructor(
+    private val repository: GroupRepository
+) {
+    operator fun invoke(groupId: Long): Flow<List<Student>> = repository.getStudentsForGroup(groupId)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GroupUseCases.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/GroupUseCases.kt
@@ -1,0 +1,14 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import javax.inject.Inject
+
+data class GroupUseCases @Inject constructor(
+    val insertGroup: InsertGroup,
+    val updateGroup: UpdateGroup,
+    val deleteGroup: DeleteGroup,
+    val getAllGroups: GetAllGroups,
+    val getGroupById: GetGroupById,
+    val addStudentToGroup: AddStudentToGroup,
+    val removeStudentFromGroup: RemoveStudentFromGroup,
+    val getGroupStudents: GetGroupStudents
+)

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/InsertGroup.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/InsertGroup.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import javax.inject.Inject
+
+class InsertGroup @Inject constructor(
+    private val repository: GroupRepository
+) {
+    suspend operator fun invoke(group: StudentGroup): Long = repository.insertGroup(group)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/RemoveStudentFromGroup.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/RemoveStudentFromGroup.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import javax.inject.Inject
+
+class RemoveStudentFromGroup @Inject constructor(
+    private val repository: GroupRepository
+) {
+    suspend operator fun invoke(groupId: Long, studentId: Long) =
+        repository.deleteCrossRef(groupId, studentId)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/UpdateGroup.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/group/UpdateGroup.kt
@@ -1,0 +1,11 @@
+package gr.tsambala.tutorbilling.domain.group
+
+import gr.tsambala.tutorbilling.data.repository.GroupRepository
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import javax.inject.Inject
+
+class UpdateGroup @Inject constructor(
+    private val repository: GroupRepository
+) {
+    suspend operator fun invoke(group: StudentGroup) = repository.updateGroup(group)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/AddGroupLesson.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/AddGroupLesson.kt
@@ -1,0 +1,12 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import javax.inject.Inject
+
+class AddGroupLesson @Inject constructor(
+    private val repository: TutorBillingRepository
+) {
+    suspend operator fun invoke(groupId: Long, lesson: Lesson): List<Long> =
+        repository.addGroupLesson(groupId, lesson)
+}

--- a/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
+++ b/domain/src/main/kotlin/gr/tsambala/tutorbilling/domain/lesson/LessonUseCases.kt
@@ -9,6 +9,7 @@ data class LessonUseCases @Inject constructor(
     val getLessonsWithStudents: GetLessonsWithStudents,
     val getLessonsWithStudentsByStudentAndDateRange: GetLessonsWithStudentsByStudentAndDateRange,
     val addLesson: AddLesson,
+    val addGroupLesson: AddGroupLesson,
     val updateLesson: UpdateLesson,
     val deleteLesson: DeleteLesson,
     val updateLessonPaidStatus: UpdateLessonPaidStatus,


### PR DESCRIPTION
## Summary
- add Group domain use cases and AddGroupLesson
- include new groupId column on Lesson and update LessonDao
- provide GroupUseCases and AddGroupLesson in DomainModule
- create repository method to add lessons for a group
- add Groups and Group screens with viewmodels
- integrate new routes and home navigation

## Testing
- `./gradlew clean assemble test lintDebug` *(fails: could not download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_687e6d32a0788330968c5cd0e8cbbd34