### PR TITLE
feat(docs): document group lessons and bump patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.20] - 2025-07-25
+## [0.20.2] - 2025-07-27
+### Added
+- Record lessons for groups of students with shared billing.
+
+## [0.20.1] - 2025-07-26
+### Added
+- Basic group management screens and domain use-cases.
+
+## [0.20.0] - 2025-07-25
 ### Added
 - Student group tables and DAO with repository and DI modules.
 - Auto-migration to database version 11.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 TutorBillingApp is an Android application for managing tutoring sessions and invoices. It uses Jetpack Compose for the UI and Room as the local database.
 
-## Features
+-## Features
 
 - Manage students grouped by class
+- Organize students into groups and schedule group lessons
 - Track lessons with billing information
 - Generate PDF invoices from selected lessons
 - Monitor revenue and past invoices

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 17
-        versionName "0.20"
+        versionName "0.20.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
- WHAT changed
  - restructure changelog with 0.20.x versions
  - bump app version to 0.20.2
  - list group lessons in README features
- WHY it matters
  - keeps history consistent for the new group functionality
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_687eae9e47b083309276505ff4c40d66