### PR TITLE
feat(lesson): allow group lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.3] - 2025-07-28
+### Added
+- Group lesson selection on Lesson screen with fee calculation.
+
+
 ## [0.20.2] - 2025-07-27
 ### Added
 - Record lessons for groups of students with shared billing.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 17
-        versionName "0.20.2"
+        versionName "0.20.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonScreen.kt
@@ -95,19 +95,31 @@ fun LessonScreen(
                 .padding(Dimensions.PaddingMedium),
             verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
         ) {
-            // Student picker
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Group Lesson")
+                Spacer(modifier = Modifier.width(8.dp))
+                Switch(checked = uiState.isGroupLesson, onCheckedChange = viewModel::toggleGroupLesson)
+            }
+
             var expanded by remember { mutableStateOf(false) }
             ExposedDropdownMenuBox(
                 expanded = expanded,
                 onExpandedChange = { expanded = !expanded }
             ) {
-                OutlinedTextField(
-                    value = uiState.selectedStudentId?.let { id ->
+                val displayText = if (uiState.isGroupLesson) {
+                    uiState.selectedGroupId?.let { id ->
+                        uiState.availableGroups.firstOrNull { it.id == id }?.name
+                    } ?: ""
+                } else {
+                    uiState.selectedStudentId?.let { id ->
                         uiState.availableStudents.firstOrNull { it.id == id }?.getFullName()
-                    } ?: "",
+                    } ?: ""
+                }
+                OutlinedTextField(
+                    value = displayText,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Student*") },
+                    label = { Text(if (uiState.isGroupLesson) "Group*" else "Student*") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                     modifier = Modifier
                         .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
@@ -117,14 +129,26 @@ fun LessonScreen(
                     expanded = expanded,
                     onDismissRequest = { expanded = false }
                 ) {
-                    uiState.availableStudents.forEach { student ->
-                        DropdownMenuItem(
-                            text = { Text(student.getFullName()) },
-                            onClick = {
-                                viewModel.updateSelectedStudent(student.id)
-                                expanded = false
-                            }
-                        )
+                    if (uiState.isGroupLesson) {
+                        uiState.availableGroups.forEach { group ->
+                            DropdownMenuItem(
+                                text = { Text(group.name) },
+                                onClick = {
+                                    viewModel.updateSelectedGroup(group.id)
+                                    expanded = false
+                                }
+                            )
+                        }
+                    } else {
+                        uiState.availableStudents.forEach { student ->
+                            DropdownMenuItem(
+                                text = { Text(student.getFullName()) },
+                                onClick = {
+                                    viewModel.updateSelectedStudent(student.id)
+                                    expanded = false
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/tsambala/tutorbilling/ui/lesson/LessonViewModel.kt
@@ -10,6 +10,7 @@ import gr.tsambala.tutorbilling.data.model.Student
 import gr.tsambala.tutorbilling.data.model.RateTypes
 import gr.tsambala.tutorbilling.domain.lesson.LessonUseCases
 import gr.tsambala.tutorbilling.domain.student.StudentUseCases
+import gr.tsambala.tutorbilling.domain.group.GroupUseCases
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,7 +23,8 @@ import javax.inject.Inject
 class LessonViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val lessonUseCases: LessonUseCases,
-    private val studentUseCases: StudentUseCases
+    private val studentUseCases: StudentUseCases,
+    private val groupUseCases: GroupUseCases
 ) : ViewModel() {
 
     private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
@@ -44,6 +46,8 @@ class LessonViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(initialState())
     val uiState: StateFlow<LessonUiState> = _uiState.asStateFlow()
 
+    private val groupMembers = mutableMapOf<Long, List<Student>>()
+
     // Navigation callback
     private var onNavigateBack: (() -> Unit)? = null
 
@@ -53,6 +57,7 @@ class LessonViewModel @Inject constructor(
 
     init {
         loadStudentInfo()
+        loadGroups()
         if (lessonId != null && lessonId != 0L) {
             loadLesson()
         }
@@ -72,6 +77,14 @@ class LessonViewModel @Inject constructor(
                         rateType = selectedStudent?.rateType ?: state.rateType
                     )
                 }
+            }
+        }
+    }
+
+    private fun loadGroups() {
+        viewModelScope.launch(Dispatchers.IO) {
+            groupUseCases.getAllGroups().collect { groups ->
+                _uiState.update { it.copy(availableGroups = groups) }
             }
         }
     }
@@ -121,11 +134,32 @@ class LessonViewModel @Inject constructor(
                             selectedStudentId = id,
                             studentName = s.name,
                             studentRate = s.rate,
-                            rateType = s.rateType
+                            rateType = s.rateType,
+                            selectedGroupId = null,
+                            isGroupLesson = false
                         )
                     }
                 }
             }
+        }
+    }
+
+    fun updateSelectedGroup(id: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            groupUseCases.getGroupStudents(id).collect { students ->
+                groupMembers[id] = students
+                _uiState.update { it.copy(selectedGroupId = id, selectedStudentId = null, isGroupLesson = true) }
+            }
+        }
+    }
+
+    fun toggleGroupLesson(value: Boolean) {
+        _uiState.update {
+            it.copy(
+                isGroupLesson = value,
+                selectedGroupId = if (value) it.selectedGroupId else null,
+                selectedStudentId = if (value) null else it.selectedStudentId
+            )
         }
     }
 
@@ -149,7 +183,7 @@ class LessonViewModel @Inject constructor(
 
     fun isFormValid(): Boolean {
         val state = _uiState.value
-        val hasStudent = state.selectedStudentId != null
+        val hasStudent = if (state.isGroupLesson) state.selectedGroupId != null else state.selectedStudentId != null
         val validDateTime = isValidDate(state.date) && isValidTime(state.startTime)
         return if (state.rateType == RateTypes.PER_LESSON) {
             hasStudent && validDateTime
@@ -178,10 +212,20 @@ class LessonViewModel @Inject constructor(
             if (!isFormValid()) return@launch
 
             val sId = state.selectedStudentId
-            sId?.let {
+            if (state.selectedGroupId != null) {
+                val lesson = Lesson(
+                    studentId = 0,
+                    date = LocalDate.parse(state.date, dateFormatter).toString(),
+                    startTime = state.startTime,
+                    durationMinutes = duration,
+                    notes = state.notes.ifBlank { null },
+                    isPaid = state.isPaid
+                )
+                lessonUseCases.addGroupLesson(state.selectedGroupId!!, lesson)
+            } else if (sId != null) {
                 if (lessonId == null || lessonId == 0L) {
                     val lesson = Lesson(
-                        studentId = it,
+                        studentId = sId,
                         date = LocalDate.parse(state.date, dateFormatter).toString(),
                         startTime = state.startTime,
                         durationMinutes = duration,
@@ -190,18 +234,16 @@ class LessonViewModel @Inject constructor(
                     )
                     lessonUseCases.addLesson(lesson)
                 } else {
-                    lessonId?.let { lId ->
-                        val lesson = Lesson(
-                            id = lId,
-                            studentId = it,
-                            date = LocalDate.parse(state.date, dateFormatter).toString(),
-                            startTime = state.startTime,
-                            durationMinutes = duration,
-                            notes = state.notes.ifBlank { null },
-                            isPaid = state.isPaid
-                        )
-                        lessonUseCases.updateLesson(lesson)
-                    }
+                    val lesson = Lesson(
+                        id = lessonId,
+                        studentId = sId,
+                        date = LocalDate.parse(state.date, dateFormatter).toString(),
+                        startTime = state.startTime,
+                        durationMinutes = duration,
+                        notes = state.notes.ifBlank { null },
+                        isPaid = state.isPaid
+                    )
+                    lessonUseCases.updateLesson(lesson)
                 }
             }
 
@@ -230,7 +272,16 @@ class LessonViewModel @Inject constructor(
     fun calculateFee(): Double {
         val state = _uiState.value
         val duration = state.durationMinutes.toIntOrNull() ?: 0
-        return if (state.rateType == RateTypes.PER_LESSON) {
+        return if (state.selectedGroupId != null) {
+            val students = groupMembers[state.selectedGroupId!!] ?: emptyList()
+            students.sumOf { student ->
+                if (state.rateType == RateTypes.PER_LESSON) {
+                    student.rate
+                } else {
+                    (duration.coerceAtLeast(60) / 60.0) * student.rate
+                }
+            }
+        } else if (state.rateType == RateTypes.PER_LESSON) {
             state.studentRate
         } else {
             (duration.coerceAtLeast(60) / 60.0) * state.studentRate
@@ -248,6 +299,9 @@ data class LessonUiState(
     val rateType: String = RateTypes.HOURLY,
     val availableStudents: List<Student> = emptyList(),
     val selectedStudentId: Long? = null,
+    val availableGroups: List<gr.tsambala.tutorbilling.data.model.StudentGroup> = emptyList(),
+    val selectedGroupId: Long? = null,
+    val isGroupLesson: Boolean = false,
     val isEditMode: Boolean = true,
     val isPaid: Boolean = false
 )

--- a/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/AddGroupLessonIntegrationTest.kt
+++ b/domain/src/test/java/gr/tsambala/tutorbilling/domain/lesson/AddGroupLessonIntegrationTest.kt
@@ -1,0 +1,60 @@
+package gr.tsambala.tutorbilling.domain.lesson
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.tsambala.tutorbilling.data.database.TutorBillingDatabase
+import gr.tsambala.tutorbilling.data.model.Lesson
+import gr.tsambala.tutorbilling.data.model.Student
+import gr.tsambala.tutorbilling.data.model.StudentGroup
+import gr.tsambala.tutorbilling.data.model.GroupStudentCrossRef
+import gr.tsambala.tutorbilling.data.repository.TutorBillingRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AddGroupLessonIntegrationTest {
+
+    private lateinit var db: TutorBillingDatabase
+    private lateinit var repository: TutorBillingRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, TutorBillingDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = TutorBillingRepository(db.studentDao(), db.lessonDao(), db.groupDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun addsLessonForEachStudentInGroup() = runBlocking {
+        val s1 = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
+        val s2 = db.studentDao().insert(Student(name = "Bob", surname = "", parentMobile = "", className = "", rate = 15.0))
+        val gId = db.groupDao().insertGroup(StudentGroup(name = "Group A"))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2))
+
+        val lesson = Lesson(studentId = 0, date = "2024-01-05", startTime = "10:00", durationMinutes = 60)
+        val useCase = AddGroupLesson(repository)
+        useCase(gId, lesson)
+
+        val l1 = db.lessonDao().getLessonsByStudentId(s1).first()
+        val l2 = db.lessonDao().getLessonsByStudentId(s2).first()
+        assertEquals(1, l1.size)
+        assertEquals(1, l2.size)
+        assertEquals(10.0, l1.first().durationMinutes / 60.0 * 10.0, 0.0)
+        assertEquals(15.0, l2.first().durationMinutes / 60.0 * 15.0, 0.0)
+    }
+}


### PR DESCRIPTION
- extend LessonUiState with group fields
- load groups in LessonViewModel and handle group save via AddGroupLesson
- add UI toggle/dropdown for selecting groups
- compute fees per student when group selected
- add integration test for AddGroupLesson

Checklist:
- [ ] Version bumped and CHANGELOG updated
- [ ] Unit tests passing
- [ ] Lint shows **0** new warnings
- [ ] `./gradlew assemble` succeeds on CI

------
https://chatgpt.com/codex/tasks/task_e_687f1ca6c3ec833094f49086c339ae4c