### PR TITLE
feat(user): add login and registration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.1] - 2025-08-01
+### Added
+- Basic user accounts with login and registration screens.
+
 ## [0.20.7] - 2025-07-31
 ### Changed
 - Namespace updated to `gr.eduinvoice`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.20.7"
+        versionName "0.21.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
+++ b/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
@@ -2,6 +2,8 @@ package gr.eduinvoice
 
 sealed class Screen(val route: String) {
     object Home : Screen("home")
+    object Login : Screen("login")
+    object Register : Screen("register")
     object Students : Screen("students")
     object Student : Screen("student/{studentId}") {
         fun createRoute(studentId: Long) = "student/$studentId"

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -2,12 +2,14 @@ package gr.eduinvoice
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.ui.home.HomeMenuScreen
 import gr.eduinvoice.ui.classes.ClassesScreen
 import gr.eduinvoice.ui.lessons.LessonsScreen
@@ -22,15 +24,44 @@ import gr.eduinvoice.ui.groups.GroupScreen
 import gr.eduinvoice.ui.settings.SettingsScreen
 import gr.eduinvoice.ui.settings.PrivacyPolicyScreen
 import gr.eduinvoice.navigation.studentGraph
+import gr.eduinvoice.ui.user.LoginScreen
+import gr.eduinvoice.ui.user.RegisterScreen
+import gr.eduinvoice.ui.user.SessionViewModel
 
 @Composable
 fun TutorBillingApp() {
     val navController = rememberNavController()
+    val sessionViewModel: SessionViewModel = hiltViewModel()
+    val loggedIn by sessionViewModel.isLoggedIn.collectAsStateWithLifecycle()
 
     NavHost(
         navController = navController,
-        startDestination = Screen.Home.route
+        startDestination = if (loggedIn) Screen.Home.route else Screen.Login.route
     ) {
+        // Authentication
+        composable(Screen.Login.route) {
+            LoginScreen(
+                onBack = { /* no-op */ },
+                onLoggedIn = {
+                    sessionViewModel.setLoggedIn(true)
+                    navController.navigate(Screen.Home.route) {
+                        popUpTo(Screen.Login.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+
+        composable(Screen.Register.route) {
+            RegisterScreen(
+                onBack = { navController.popBackStack() },
+                onRegistered = {
+                    navController.navigate(Screen.Home.route) {
+                        popUpTo(Screen.Register.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+
         // Home Screen
         composable(Screen.Home.route) {
             HomeMenuScreen(

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -1,0 +1,61 @@
+package gr.eduinvoice.ui.user
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen(
+    onBack: () -> Unit,
+    onLoggedIn: () -> Unit,
+    viewModel: LoginViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Login") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = uiState.username,
+                onValueChange = viewModel::updateUsername,
+                label = { Text("Username") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(onClick = { viewModel.login(onLoggedIn) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Login")
+            }
+            uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        }
+    }
+}

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginViewModel.kt
@@ -1,0 +1,44 @@
+package gr.eduinvoice.ui.user
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.eduinvoice.domain.user.UserUseCases
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val useCases: UserUseCases,
+    private val prefs: UserPreferencesRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    fun updateUsername(value: String) { _uiState.value = _uiState.value.copy(username = value) }
+    fun updatePassword(value: String) { _uiState.value = _uiState.value.copy(password = value) }
+
+    fun login(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            val user = useCases.authenticateUser(_uiState.value.username, _uiState.value.password)
+            if (user != null) {
+                prefs.setLoggedIn(true)
+                onSuccess()
+            } else {
+                _uiState.value = _uiState.value.copy(error = "Invalid credentials")
+            }
+        }
+    }
+
+    fun dismissError() { _uiState.value = _uiState.value.copy(error = null) }
+}
+
+data class LoginUiState(
+    val username: String = "",
+    val password: String = "",
+    val error: String? = null
+)

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -1,0 +1,66 @@
+package gr.eduinvoice.ui.user
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RegisterScreen(
+    onBack: () -> Unit,
+    onRegistered: () -> Unit,
+    viewModel: RegisterViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Register") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = uiState.fullName,
+                onValueChange = viewModel::updateFullName,
+                label = { Text("Full Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = uiState.username,
+                onValueChange = viewModel::updateUsername,
+                label = { Text("Username") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = uiState.password,
+                onValueChange = viewModel::updatePassword,
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(onClick = { viewModel.register(onRegistered) }, modifier = Modifier.fillMaxWidth()) {
+                Text("Register")
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
@@ -1,0 +1,43 @@
+package gr.eduinvoice.ui.user
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.domain.user.UserUseCases
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterViewModel @Inject constructor(
+    private val useCases: UserUseCases,
+    private val prefs: UserPreferencesRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(RegisterUiState())
+    val uiState: StateFlow<RegisterUiState> = _uiState.asStateFlow()
+
+    fun updateUsername(value: String) { _uiState.value = _uiState.value.copy(username = value) }
+    fun updatePassword(value: String) { _uiState.value = _uiState.value.copy(password = value) }
+    fun updateFullName(value: String) { _uiState.value = _uiState.value.copy(fullName = value) }
+
+    fun register(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            val user = User(username = _uiState.value.username,
+                passwordHash = _uiState.value.password,
+                fullName = _uiState.value.fullName)
+            useCases.createUser(user)
+            prefs.setLoggedIn(true)
+            onSuccess()
+        }
+    }
+}
+
+data class RegisterUiState(
+    val username: String = "",
+    val password: String = "",
+    val fullName: String = ""
+)

--- a/app/src/main/java/gr/eduinvoice/ui/user/SessionViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/SessionViewModel.kt
@@ -1,0 +1,26 @@
+package gr.eduinvoice.ui.user
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SessionViewModel @Inject constructor(
+    private val prefs: UserPreferencesRepository
+) : ViewModel() {
+    val isLoggedIn: StateFlow<Boolean> = prefs.isLoggedIn.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+    )
+
+    fun setLoggedIn(value: Boolean) {
+        viewModelScope.launch { prefs.setLoggedIn(value) }
+    }
+}

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/12.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/12.json
@@ -1,0 +1,300 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "b83c1ded6e0687f104d33967dcc0c03a",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b83c1ded6e0687f104d33967dcc0c03a')"
+    ]
+  }
+}

--- a/data/src/main/java/gr/eduinvoice/data/dao/UserDao.kt
+++ b/data/src/main/java/gr/eduinvoice/data/dao/UserDao.kt
@@ -1,0 +1,23 @@
+package gr.eduinvoice.data.dao
+
+import androidx.room.*
+import gr.eduinvoice.data.model.User
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UserDao {
+    @Insert
+    suspend fun insert(user: User): Long
+
+    @Update
+    suspend fun update(user: User)
+
+    @Delete
+    suspend fun delete(user: User)
+
+    @Query("SELECT * FROM ${gr.eduinvoice.data.database.DatabaseConstants.USERS_TABLE} WHERE id = :id")
+    fun getUserById(id: Long): Flow<User?>
+
+    @Query("SELECT * FROM ${gr.eduinvoice.data.database.DatabaseConstants.USERS_TABLE} WHERE username = :username LIMIT 1")
+    suspend fun getByUsername(username: String): User?
+}

--- a/data/src/main/java/gr/eduinvoice/data/database/DatabaseConstants.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/DatabaseConstants.kt
@@ -6,4 +6,5 @@ object DatabaseConstants {
     const val LESSONS_TABLE = "lessons"
     const val GROUPS_TABLE = "student_groups"
     const val GROUP_STUDENT_CROSS_REF_TABLE = "group_student_cross_ref"
+    const val USERS_TABLE = "users"
 }

--- a/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
@@ -9,14 +9,16 @@ import androidx.room.RoomDatabase
 import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.dao.StudentDao
+import gr.eduinvoice.data.dao.UserDao
 import gr.eduinvoice.data.model.GroupStudentCrossRef
 import gr.eduinvoice.data.model.Lesson
 import gr.eduinvoice.data.model.Student
 import gr.eduinvoice.data.model.StudentGroup
+import gr.eduinvoice.data.model.User
 
 @Database(
-    entities = [Student::class, Lesson::class, StudentGroup::class, GroupStudentCrossRef::class],
-    version = 11, // Current version
+    entities = [Student::class, Lesson::class, StudentGroup::class, GroupStudentCrossRef::class, User::class],
+    version = 12,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
@@ -24,13 +26,15 @@ import gr.eduinvoice.data.model.StudentGroup
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
-        AutoMigration(from = 10, to = 11)
+        AutoMigration(from = 10, to = 11),
+        AutoMigration(from = 11, to = 12)
     ]
 )
 abstract class EduInvoiceDatabase : RoomDatabase() {
     abstract fun studentDao(): StudentDao
     abstract fun lessonDao(): LessonDao
     abstract fun groupDao(): GroupDao
+    abstract fun userDao(): UserDao
 
     companion object {
         @Volatile

--- a/data/src/main/java/gr/eduinvoice/data/di/DaoModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DaoModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.dao.StudentDao
+import gr.eduinvoice.data.dao.UserDao
 import gr.eduinvoice.data.database.EduInvoiceDatabase
 
 @Module
@@ -20,4 +21,7 @@ object DaoModule {
 
     @Provides
     fun provideGroupDao(db: EduInvoiceDatabase): GroupDao = db.groupDao()
+
+    @Provides
+    fun provideUserDao(db: EduInvoiceDatabase): UserDao = db.userDao()
 }

--- a/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.components.SingletonComponent
 import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.dao.StudentDao
+import gr.eduinvoice.data.dao.UserDao
 import gr.eduinvoice.data.repository.StudentRepository
 import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.data.repository.GroupRepository
+import gr.eduinvoice.data.repository.UserRepository
 import javax.inject.Singleton
 
 @Module
@@ -24,6 +26,11 @@ object RepositoryModule {
     @Singleton
     fun provideGroupRepository(groupDao: GroupDao): GroupRepository =
         GroupRepository(groupDao)
+
+    @Provides
+    @Singleton
+    fun provideUserRepository(userDao: UserDao): UserRepository =
+        UserRepository(userDao)
 
     @Provides
     @Singleton

--- a/data/src/main/java/gr/eduinvoice/data/model/User.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/User.kt
@@ -1,0 +1,18 @@
+package gr.eduinvoice.data.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import gr.eduinvoice.data.database.DatabaseConstants
+
+@Entity(
+    tableName = DatabaseConstants.USERS_TABLE,
+    indices = [Index(value = ["username"], unique = true)]
+)
+data class User(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val username: String,
+    val passwordHash: String,
+    val fullName: String
+)

--- a/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
@@ -1,0 +1,23 @@
+package gr.eduinvoice.data.repository
+
+import gr.eduinvoice.data.dao.UserDao
+import gr.eduinvoice.data.model.User
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserRepository @Inject constructor(
+    private val dao: UserDao
+) {
+    suspend fun createUser(user: User): Long = dao.insert(user)
+    fun getUserById(id: Long): Flow<User?> = dao.getUserById(id)
+    suspend fun getByUsername(username: String): User? = dao.getByUsername(username)
+    suspend fun updateUser(user: User) = dao.update(user)
+    suspend fun deleteUser(user: User) = dao.delete(user)
+
+    suspend fun authenticate(username: String, passwordHash: String): User? {
+        val user = dao.getByUsername(username) ?: return null
+        return if (user.passwordHash == passwordHash) user else null
+    }
+}

--- a/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
@@ -1,0 +1,30 @@
+package gr.eduinvoice.data.user
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.userPrefsDataStore by preferencesDataStore(name = "user_prefs")
+
+@Singleton
+class UserPreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private object Keys {
+        val LOGGED_IN = booleanPreferencesKey("logged_in")
+    }
+
+    val isLoggedIn: Flow<Boolean> = context.userPrefsDataStore.data.map { prefs ->
+        prefs[Keys.LOGGED_IN] ?: false
+    }
+
+    suspend fun setLoggedIn(value: Boolean) {
+        context.userPrefsDataStore.edit { it[Keys.LOGGED_IN] = value }
+    }
+}

--- a/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
@@ -1,0 +1,41 @@
+package gr.eduinvoice.data.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.model.User
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UserDaoTest {
+    private lateinit var db: EduInvoiceDatabase
+    private lateinit var dao: UserDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EduInvoiceDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.userDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertAndQueryByUsername() = runBlocking {
+        dao.insert(User(username = "bob", passwordHash = "pass", fullName = "Bob"))
+        val user = dao.getByUsername("bob")
+        assertEquals("Bob", user?.fullName)
+    }
+}

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/di/DomainModule.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/di/DomainModule.kt
@@ -8,9 +8,11 @@ import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.repository.StudentRepository
 import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.data.repository.GroupRepository
+import gr.eduinvoice.data.repository.UserRepository
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
 import gr.eduinvoice.domain.group.*
+import gr.eduinvoice.domain.user.*
 import javax.inject.Singleton
 
 @Module
@@ -43,6 +45,15 @@ object DomainModule {
             addStudentToGroup = AddStudentToGroup(repository),
             removeStudentFromGroup = RemoveStudentFromGroup(repository),
             getGroupStudents = GetGroupStudents(repository)
+        )
+
+    @Provides
+    @Singleton
+    fun provideUserUseCases(repository: UserRepository): UserUseCases =
+        UserUseCases(
+            createUser = CreateUser(repository),
+            authenticateUser = AuthenticateUser(repository),
+            getUserProfile = GetUserProfile(repository)
         )
 
     @Provides

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/AuthenticateUser.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/AuthenticateUser.kt
@@ -1,0 +1,12 @@
+package gr.eduinvoice.domain.user
+
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import javax.inject.Inject
+
+class AuthenticateUser @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(username: String, passwordHash: String): User? =
+        repository.authenticate(username, passwordHash)
+}

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/CreateUser.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/CreateUser.kt
@@ -1,0 +1,11 @@
+package gr.eduinvoice.domain.user
+
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import javax.inject.Inject
+
+class CreateUser @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(user: User): Long = repository.createUser(user)
+}

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/GetUserProfile.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/GetUserProfile.kt
@@ -1,0 +1,12 @@
+package gr.eduinvoice.domain.user
+
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetUserProfile @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(id: Long): Flow<User?> = repository.getUserById(id)
+}

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/UserUseCases.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/UserUseCases.kt
@@ -1,0 +1,9 @@
+package gr.eduinvoice.domain.user
+
+import javax.inject.Inject
+
+data class UserUseCases @Inject constructor(
+    val createUser: CreateUser,
+    val authenticateUser: AuthenticateUser,
+    val getUserProfile: GetUserProfile
+)

--- a/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
@@ -1,0 +1,52 @@
+package gr.eduinvoice.domain.user
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.repository.UserRepository
+import gr.eduinvoice.data.model.User
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AuthenticateUserTest {
+    private lateinit var db: EduInvoiceDatabase
+    private lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EduInvoiceDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = UserRepository(db.userDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun authenticateUserWithCorrectCredentials() = runBlocking {
+        repository.createUser(User(username = "alice", passwordHash = "hash", fullName = "Alice"))
+        val useCase = AuthenticateUser(repository)
+        val user = useCase("alice", "hash")
+        assertNotNull(user)
+    }
+
+    @Test
+    fun authenticateUserWithWrongCredentials() = runBlocking {
+        repository.createUser(User(username = "alice", passwordHash = "hash", fullName = "Alice"))
+        val useCase = AuthenticateUser(repository)
+        val user = useCase("alice", "wrong")
+        assertNull(user)
+    }
+}


### PR DESCRIPTION
- add User entity, DAO and repository with DataStore for session
- expose user use-cases and Hilt module wiring
- implement login and registration screens with SessionViewModel
- route to login when not authenticated
- bump version to 0.21.1 and document in changelog

`./gradlew lintDebug` succeeds but unit tests fail due to blocked network resources

------
https://chatgpt.com/codex/tasks/task_e_6880b018dc1483309b957b24950e680d