### PR TITLE
fix(lessons): use named lesson args in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.4] - 2025-08-04
+### Changed
+- Updated lesson tests to construct `Lesson` with named arguments.
+
 ## [0.21.3] - 2025-08-03
 ### Changed
 - Updated lesson-related integration tests to use group DAO when constructing `TutorBillingRepository`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.3"
+        versionName "0.21.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -63,8 +63,30 @@ class LessonsScreenTest {
         val s2 = Student(id = 2, name = "Bob", surname = "", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 1, null, today, "10:00", 60, null, false), s1),
-            LessonWithStudent(Lesson(2, 2, null, today, "11:00", 60, null, false), s2)
+            LessonWithStudent(
+                Lesson(
+                    id = 1,
+                    studentId = 1,
+                    date = today,
+                    startTime = "10:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                s1
+            ),
+            LessonWithStudent(
+                Lesson(
+                    id = 2,
+                    studentId = 2,
+                    date = today,
+                    startTime = "11:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                s2
+            )
         )
         val vm = LessonsViewModel(lessonUseCases)
         composeRule.setContent {
@@ -81,7 +103,18 @@ class LessonsScreenTest {
         val s1 = Student(id = 1, name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 1, null, today, "10:00", 60, null, false), s1)
+            LessonWithStudent(
+                Lesson(
+                    id = 1,
+                    studentId = 1,
+                    date = today,
+                    startTime = "10:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                s1
+            )
         )
         val vm = LessonsViewModel(lessonUseCases)
         var clicked = false

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -59,8 +59,30 @@ class LessonsViewModelTest {
         val s2 = Student(id = 2, name = "Bob", surname = "B", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 2, null, today, "10:00", 60, null, false), s2),
-            LessonWithStudent(Lesson(2, 1, null, today, "11:00", 60, null, false), s1)
+            LessonWithStudent(
+                Lesson(
+                    id = 1,
+                    studentId = 2,
+                    date = today,
+                    startTime = "10:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                s2
+            ),
+            LessonWithStudent(
+                Lesson(
+                    id = 2,
+                    studentId = 1,
+                    date = today,
+                    startTime = "11:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                s1
+            )
         )
 
         val vm = LessonsViewModel(lessonUseCases)
@@ -76,7 +98,18 @@ class LessonsViewModelTest {
         val student = Student(id = 1, name = "Alice", surname = "A", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 1, null, today, "10:00", 60), student)
+            LessonWithStudent(
+                Lesson(
+                    id = 1,
+                    studentId = 1,
+                    date = today,
+                    startTime = "10:00",
+                    durationMinutes = 60,
+                    notes = null,
+                    isPaid = false
+                ),
+                student
+            )
         )
 
         val vm = LessonsViewModel(lessonUseCases)
@@ -93,7 +126,17 @@ class LessonsViewModelTest {
         val student = Student(id = 1, name = "Alice", surname = "A", parentMobile = "", className = "", rate = 10.0)
         val today = LocalDate.now().toString()
         lessonFlow.value = listOf(
-            LessonWithStudent(Lesson(1, 1, null, today, "10:00", 60, isInvoiced = true), student)
+            LessonWithStudent(
+                Lesson(
+                    id = 1,
+                    studentId = 1,
+                    date = today,
+                    startTime = "10:00",
+                    durationMinutes = 60,
+                    isInvoiced = true
+                ),
+                student
+            )
         )
 
         val vm = LessonsViewModel(lessonUseCases)


### PR DESCRIPTION
- replace positional Lesson ctor usages with named parameters
- bump version to 0.21.4

```
./gradlew clean
./gradlew assemble
./gradlew test
./gradlew lintDebug
```


------
https://chatgpt.com/codex/tasks/task_e_68825d1dcc408330949c0711b36878ef