### PR TITLE
feat(ui): add welcome screen

### DIFF
--- a/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
+++ b/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
@@ -1,6 +1,7 @@
 package gr.eduinvoice
 
 sealed class Screen(val route: String) {
+    object Welcome : Screen("welcome")
     object Home : Screen("home")
     object Login : Screen("login")
     object Register : Screen("register")

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -1,5 +1,6 @@
 package gr.eduinvoice
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -8,6 +9,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.ui.home.HomeMenuScreen
@@ -23,6 +25,7 @@ import gr.eduinvoice.ui.groups.GroupsScreen
 import gr.eduinvoice.ui.groups.GroupScreen
 import gr.eduinvoice.ui.settings.SettingsScreen
 import gr.eduinvoice.ui.settings.PrivacyPolicyScreen
+import gr.eduinvoice.ui.welcome.WelcomeScreen
 import gr.eduinvoice.navigation.studentGraph
 import gr.eduinvoice.ui.user.LoginScreen
 import gr.eduinvoice.ui.user.RegisterScreen
@@ -34,17 +37,27 @@ fun TutorBillingApp() {
     val sessionViewModel: SessionViewModel = hiltViewModel()
     val loggedIn by sessionViewModel.isLoggedIn.collectAsStateWithLifecycle()
 
+    val startDestination = if (loggedIn) Screen.Home.route else Screen.Welcome.route
+
     NavHost(
         navController = navController,
-        startDestination = if (loggedIn) Screen.Home.route else Screen.Login.route
+        startDestination = startDestination
     ) {
         // Authentication
+        composable(Screen.Welcome.route) {
+            gr.eduinvoice.ui.welcome.WelcomeScreen(
+                onSignIn = { navController.navigate(Screen.Login.route) },
+                onSignUp = { navController.navigate(Screen.Register.route) },
+                onSettings = { navController.navigate(Screen.Settings.route) }
+            )
+        }
+
         composable(Screen.Login.route) {
             LoginScreen(
-                onBack = { /* no-op */ },
+                onBack = { navController.popBackStack() },
                 onLoggedIn = {
                     navController.navigate(Screen.Home.route) {
-                        popUpTo(Screen.Login.route) { inclusive = true }
+                        popUpTo(Screen.Welcome.route) { inclusive = true }
                     }
                 },
                 onRegister = { navController.navigate(Screen.Register.route) }
@@ -56,7 +69,7 @@ fun TutorBillingApp() {
                 onBack = { navController.popBackStack() },
                 onRegistered = {
                     navController.navigate(Screen.Home.route) {
-                        popUpTo(Screen.Register.route) { inclusive = true }
+                        popUpTo(Screen.Welcome.route) { inclusive = true }
                     }
                 }
             )
@@ -159,7 +172,7 @@ fun TutorBillingApp() {
                 onPrivacyPolicy = { navController.navigate(Screen.PrivacyPolicy.route) },
                 onLogout = {
                     sessionViewModel.logout()
-                    navController.navigate(Screen.Login.route) {
+                    navController.navigate(Screen.Welcome.route) {
                         popUpTo(Screen.Home.route) { inclusive = true }
                     }
                 }

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -1,6 +1,9 @@
 package gr.eduinvoice.ui.user
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -34,6 +37,11 @@ fun LoginScreen(
             )
         }
     ) { padding ->
+        AnimatedVisibility(
+            visible = true,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -61,6 +69,7 @@ fun LoginScreen(
                 Text("Register")
             }
             uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        }
         }
     }
 }

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -1,6 +1,9 @@
 package gr.eduinvoice.ui.user
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -32,6 +35,11 @@ fun RegisterScreen(
             )
         }
     ) { padding ->
+        AnimatedVisibility(
+            visible = true,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -62,6 +70,7 @@ fun RegisterScreen(
                 Text("Register")
             }
             uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        }
         }
     }
 }

--- a/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
@@ -1,0 +1,85 @@
+package gr.eduinvoice.ui.welcome
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import gr.eduinvoice.R
+import gr.eduinvoice.ui.design.AppColors
+import gr.eduinvoice.ui.design.AppTopBar
+import gr.eduinvoice.ui.design.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WelcomeScreen(
+    onSignIn: () -> Unit,
+    onSignUp: () -> Unit,
+    onSettings: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = stringResource(R.string.app_name),
+                actions = {
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        AnimatedVisibility(
+            visible = true,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(Dimensions.PaddingMedium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
+        ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Image(
+                painter = painterResource(R.drawable.tutorbilling_logo),
+                contentDescription = stringResource(R.string.app_logo_desc),
+                modifier = Modifier.size(200.dp)
+            )
+            Text(
+                text = stringResource(R.string.welcome_message),
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(vertical = Dimensions.PaddingMedium)
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(
+                    onClick = onSignIn,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.primaryContainer)
+                ) { Text(stringResource(R.string.sign_in)) }
+                Button(
+                    onClick = onSignUp,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.secondaryContainer)
+                ) { Text(stringResource(R.string.sign_up)) }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+        }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,4 +77,9 @@
     <string name="privacy_policy_text">Your privacy is important to us. This app stores minimal personal data locally on your device.</string>
     <string name="open_in_browser">Open in Browser</string>
     <string name="privacy_policy_url">https://example.com/privacy</string>
+
+    <!-- Welcome screen -->
+    <string name="welcome_message">Welcome to EduInvoice</string>
+    <string name="sign_in">Sign In</string>
+    <string name="sign_up">Sign Up</string>
 </resources>


### PR DESCRIPTION
- added new Welcome screen with animated appearance and navigation buttons
- start app on welcome screen when user not logged in
- updated navigation routes and logout flow
- provided basic fade-in transitions

`./gradlew assemble` succeeded, but unit tests failed due to network issues.


------
https://chatgpt.com/codex/tasks/task_e_68826c88af4c8330bffd7189a510e77b