### PR TITLE
feat(auth): add logo and settings access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.5] - 2025-08-05
+### Added
+- Logo and settings access on login and register screens.
+
 ## [0.21.4] - 2025-08-04
 ### Changed
 - Updated lesson tests to construct `Lesson` with named arguments.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.4"
+        versionName "0.21.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -60,7 +60,8 @@ fun TutorBillingApp() {
                         popUpTo(Screen.Welcome.route) { inclusive = true }
                     }
                 },
-                onRegister = { navController.navigate(Screen.Register.route) }
+                onRegister = { navController.navigate(Screen.Register.route) },
+                onSettings = { navController.navigate(Screen.Settings.route) }
             )
         }
 
@@ -71,7 +72,8 @@ fun TutorBillingApp() {
                     navController.navigate(Screen.Home.route) {
                         popUpTo(Screen.Welcome.route) { inclusive = true }
                     }
-                }
+                },
+                onSettings = { navController.navigate(Screen.Settings.route) }
             )
         }
 

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -1,19 +1,24 @@
 package gr.eduinvoice.ui.user
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.eduinvoice.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -21,6 +26,7 @@ fun LoginScreen(
     onBack: () -> Unit,
     onLoggedIn: () -> Unit,
     onRegister: () -> Unit,
+    onSettings: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -28,10 +34,15 @@ fun LoginScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Login") },
+                title = { Text(stringResource(R.string.login)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings))
                     }
                 }
             )
@@ -49,24 +60,32 @@ fun LoginScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Image(
+                painter = painterResource(R.drawable.tutorbilling_logo),
+                contentDescription = stringResource(R.string.app_logo_desc),
+                modifier = Modifier
+                    .size(200.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
             OutlinedTextField(
                 value = uiState.username,
                 onValueChange = viewModel::updateUsername,
-                label = { Text("Username") },
+                label = { Text(stringResource(R.string.username)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = uiState.password,
                 onValueChange = viewModel::updatePassword,
-                label = { Text("Password") },
+                label = { Text(stringResource(R.string.password)) },
                 visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth()
             )
             Button(onClick = { viewModel.login { onLoggedIn() } }, modifier = Modifier.fillMaxWidth()) {
-                Text("Login")
+                Text(stringResource(R.string.login))
             }
             TextButton(onClick = onRegister, modifier = Modifier.align(Alignment.End)) {
-                Text("Register")
+                Text(stringResource(R.string.register))
             }
             uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
         }

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -1,24 +1,31 @@
 package gr.eduinvoice.ui.user
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.eduinvoice.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RegisterScreen(
     onBack: () -> Unit,
     onRegistered: () -> Unit,
+    onSettings: () -> Unit,
     viewModel: RegisterViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -26,10 +33,15 @@ fun RegisterScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Register") },
+                title = { Text(stringResource(R.string.register)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings))
                     }
                 }
             )
@@ -47,27 +59,35 @@ fun RegisterScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Image(
+                painter = painterResource(R.drawable.tutorbilling_logo),
+                contentDescription = stringResource(R.string.app_logo_desc),
+                modifier = Modifier
+                    .size(200.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
             OutlinedTextField(
                 value = uiState.fullName,
                 onValueChange = viewModel::updateFullName,
-                label = { Text("Full Name") },
+                label = { Text(stringResource(R.string.full_name)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = uiState.username,
                 onValueChange = viewModel::updateUsername,
-                label = { Text("Username") },
+                label = { Text(stringResource(R.string.username)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = uiState.password,
                 onValueChange = viewModel::updatePassword,
-                label = { Text("Password") },
+                label = { Text(stringResource(R.string.password)) },
                 visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth()
             )
             Button(onClick = { viewModel.register(onRegistered) }, modifier = Modifier.fillMaxWidth()) {
-                Text("Register")
+                Text(stringResource(R.string.register))
             }
             uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,12 @@
     <string name="welcome_message">Welcome to EduInvoice</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
+    
+    <!-- Authentication -->
+    <string name="username">Username</string>
+    <string name="password">Password</string>
+    <string name="login">Login</string>
+    <string name="register">Register</string>
+    <string name="full_name">Full Name</string>
+    <string name="settings">Settings</string>
 </resources>


### PR DESCRIPTION
- Added logo and settings button to login and register screens
- Moved hard-coded auth labels to strings.xml
- Updated navigation to pass settings action
- Bumped version to 0.21.5

`./gradlew test` (fails)
`./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_68827395ea2483309ba8b0fc11acf6e7