### PR TITLE
feat(user): extend profile fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.5] - 2025-08-05
+### Added
+- User profile fields `subjectSpecialty` and `yearsExperience` with auto-migration.
+
 ## [0.21.4] - 2025-08-04
 ### Changed
 - Updated lesson tests to construct `Lesson` with named arguments.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.4"
+        versionName "0.21.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -60,6 +60,18 @@ fun RegisterScreen(
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
+                value = uiState.subjectSpecialty,
+                onValueChange = viewModel::updateSubjectSpecialty,
+                label = { Text("Subject Specialty") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
+                onValueChange = viewModel::updateYearsExperience,
+                label = { Text("Years Experience") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
                 value = uiState.password,
                 onValueChange = viewModel::updatePassword,
                 label = { Text("Password") },

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
@@ -24,13 +24,20 @@ class RegisterViewModel @Inject constructor(
     fun updateUsername(value: String) { _uiState.value = _uiState.value.copy(username = value) }
     fun updatePassword(value: String) { _uiState.value = _uiState.value.copy(password = value) }
     fun updateFullName(value: String) { _uiState.value = _uiState.value.copy(fullName = value) }
+    fun updateSubjectSpecialty(value: String) { _uiState.value = _uiState.value.copy(subjectSpecialty = value) }
+    fun updateYearsExperience(value: String) {
+        val years = value.toIntOrNull() ?: 0
+        _uiState.value = _uiState.value.copy(yearsExperience = years)
+    }
 
     fun register(onSuccess: () -> Unit) {
         viewModelScope.launch {
             val user = User(
                 username = _uiState.value.username,
                 passwordHash = _uiState.value.password,
-                fullName = _uiState.value.fullName
+                fullName = _uiState.value.fullName,
+                subjectSpecialty = _uiState.value.subjectSpecialty,
+                yearsExperience = _uiState.value.yearsExperience
             )
             try {
                 val id = useCases.createUser(user)
@@ -49,5 +56,7 @@ data class RegisterUiState(
     val username: String = "",
     val password: String = "",
     val fullName: String = "",
+    val subjectSpecialty: String = "",
+    val yearsExperience: Int = 0,
     val error: String? = null
 )

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/14.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/14.json
@@ -1,0 +1,338 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "614b5a4d004778f51f1de2f0f56f3d6f",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '614b5a4d004778f51f1de2f0f56f3d6f')"
+    ]
+  }
+}

--- a/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
@@ -18,7 +18,7 @@ import gr.eduinvoice.data.database.MIGRATION_12_13
 
 @Database(
     entities = [Student::class, Lesson::class, StudentGroup::class, GroupStudentCrossRef::class, User::class],
-    version = 13,
+    version = 14,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 5, to = 6, spec = AutoMigration5To6::class),
@@ -27,7 +27,8 @@ import gr.eduinvoice.data.database.MIGRATION_12_13
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
         AutoMigration(from = 10, to = 11),
-        AutoMigration(from = 11, to = 12)
+        AutoMigration(from = 11, to = 12),
+        AutoMigration(from = 13, to = 14)
     ]
 )
 abstract class EduInvoiceDatabase : RoomDatabase() {

--- a/data/src/main/java/gr/eduinvoice/data/model/User.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/User.kt
@@ -1,5 +1,6 @@
 package gr.eduinvoice.data.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -14,5 +15,9 @@ data class User(
     val id: Long = 0,
     val username: String,
     val passwordHash: String,
-    val fullName: String
+    val fullName: String,
+    @ColumnInfo(defaultValue = "''")
+    val subjectSpecialty: String = "",
+    @ColumnInfo(defaultValue = "0")
+    val yearsExperience: Int = 0
 )

--- a/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
@@ -34,7 +34,15 @@ class UserDaoTest {
 
     @Test
     fun insertAndQueryByUsername() = runBlocking {
-        dao.insert(User(username = "bob", passwordHash = "pass", fullName = "Bob"))
+        dao.insert(
+            User(
+                username = "bob",
+                passwordHash = "pass",
+                fullName = "Bob",
+                subjectSpecialty = "Math",
+                yearsExperience = 5
+            )
+        )
         val user = dao.getByUsername("bob")
         assertEquals("Bob", user?.fullName)
     }

--- a/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
@@ -36,7 +36,15 @@ class AuthenticateUserTest {
 
     @Test
     fun authenticateUserWithCorrectCredentials() = runBlocking {
-        repository.createUser(User(username = "alice", passwordHash = "password", fullName = "Alice"))
+        repository.createUser(
+            User(
+                username = "alice",
+                passwordHash = "password",
+                fullName = "Alice",
+                subjectSpecialty = "Physics",
+                yearsExperience = 3
+            )
+        )
         val useCase = AuthenticateUser(repository)
         val user = useCase("alice", "password")
         assertNotNull(user)
@@ -44,7 +52,15 @@ class AuthenticateUserTest {
 
     @Test
     fun authenticateUserWithWrongCredentials() = runBlocking {
-        repository.createUser(User(username = "alice", passwordHash = "password", fullName = "Alice"))
+        repository.createUser(
+            User(
+                username = "alice",
+                passwordHash = "password",
+                fullName = "Alice",
+                subjectSpecialty = "Physics",
+                yearsExperience = 3
+            )
+        )
         val useCase = AuthenticateUser(repository)
         val user = useCase("alice", "wrong")
         assertNull(user)


### PR DESCRIPTION
## Summary
- add `subjectSpecialty` and `yearsExperience` to `User`
- bump database to version 14 with auto‑migration
- capture new fields in registration UI and ViewModel
- update user tests and Room schema
- bump app version to 0.21.5

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: Execution failed for task :app:testDebugUnitTest)*
- `./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_68827396d3148330b75c6218cd07a49d