### PR TITLE
feat(settings): categorize with account info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.7] - 2025-08-07
+### Added
+- Categorised settings screen with account info
+- Strings extracted for login and registration
+
 ## [0.21.6] - 2025-08-06
 ### Changed
 - Number keyboard for entering years of experience in registration

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.6"
+        versionName "0.21.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -20,8 +20,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val viewModel: SettingsViewModel = hiltViewModel()
-            val settings = viewModel.settings.collectAsStateWithLifecycle().value
-            TutorBillingTheme(darkTheme = settings.darkTheme) {
+            val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+            TutorBillingTheme(darkTheme = uiState.settings.darkTheme) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -172,9 +172,17 @@ fun TutorBillingApp() {
             SettingsScreen(
                 onBack = { navController.popBackStack() },
                 onPrivacyPolicy = { navController.navigate(Screen.PrivacyPolicy.route) },
+                onLogin = { navController.navigate(Screen.Login.route) },
+                onRegister = { navController.navigate(Screen.Register.route) },
                 onLogout = {
                     sessionViewModel.logout()
                     navController.navigate(Screen.Welcome.route) {
+                        popUpTo(Screen.Home.route) { inclusive = true }
+                    }
+                },
+                onSwitchAccount = {
+                    sessionViewModel.logout()
+                    navController.navigate(Screen.Login.route) {
                         popUpTo(Screen.Home.route) { inclusive = true }
                     }
                 }

--- a/app/src/main/java/gr/eduinvoice/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/revenue/RevenueScreen.kt
@@ -33,7 +33,8 @@ fun RevenueScreen(
     settingsViewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val settings by settingsViewModel.settings.collectAsStateWithLifecycle()
+    val settingsState by settingsViewModel.uiState.collectAsStateWithLifecycle()
+    val settings = settingsState.settings
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
@@ -22,18 +22,24 @@ import gr.eduinvoice.R
 fun SettingsScreen(
     onBack: () -> Unit,
     onPrivacyPolicy: () -> Unit,
+    onLogin: () -> Unit,
+    onRegister: () -> Unit,
     onLogout: () -> Unit,
+    onSwitchAccount: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    val settings by viewModel.settings.collectAsStateWithLifecycle()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
             AppTopBar(
-                title = "Settings",
+                title = stringResource(R.string.settings),
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
                     }
                 }
             )
@@ -46,14 +52,15 @@ fun SettingsScreen(
                 .padding(Dimensions.PaddingMedium),
             verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
         ) {
+            Text(stringResource(R.string.general), style = MaterialTheme.typography.titleMedium)
             SettingCard(containerColor = MaterialTheme.colorScheme.primaryContainer) {
                 var expanded by remember { mutableStateOf(false) }
                 ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
                     OutlinedTextField(
-                        value = settings.currencySymbol,
+                        value = state.settings.currencySymbol,
                         onValueChange = {},
                         readOnly = true,
-                        label = { Text("Currency") },
+                        label = { Text(stringResource(R.string.currency)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                         modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true).fillMaxWidth()
                     )
@@ -71,10 +78,10 @@ fun SettingsScreen(
                 var expanded by remember { mutableStateOf(false) }
                 ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
                     OutlinedTextField(
-                        value = settings.roundingDecimals.toString(),
+                        value = state.settings.roundingDecimals.toString(),
                         onValueChange = {},
                         readOnly = true,
-                        label = { Text("Decimal places") },
+                        label = { Text(stringResource(R.string.decimal_places)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                         modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true).fillMaxWidth()
                     )
@@ -88,17 +95,46 @@ fun SettingsScreen(
                     }
                 }
             }
+
+            Text(stringResource(R.string.appearance), style = MaterialTheme.typography.titleMedium)
             SettingCard(containerColor = MaterialTheme.colorScheme.tertiaryContainer) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Dark theme")
+                    Text(stringResource(R.string.dark_theme))
                     Switch(
-                        checked = settings.darkTheme,
+                        checked = state.settings.darkTheme,
                         onCheckedChange = viewModel::updateDarkTheme
                     )
+                }
+            }
+            Text(stringResource(R.string.account), style = MaterialTheme.typography.titleMedium)
+            state.user?.let { user ->
+                Text(user.fullName.ifBlank { user.username }, style = MaterialTheme.typography.bodyLarge)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Button(onClick = onLogout, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.logout))
+                    }
+                    Button(onClick = onSwitchAccount, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.switch_account))
+                    }
+                }
+            } ?: run {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Button(onClick = onLogin, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.sign_in))
+                    }
+                    Button(onClick = onRegister, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.sign_up))
+                    }
                 }
             }
 
@@ -108,14 +144,6 @@ fun SettingsScreen(
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.errorContainer)
             ) {
                 Text(stringResource(R.string.privacy_policy))
-            }
-
-            Button(
-                onClick = onLogout,
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.errorContainer)
-            ) {
-                Text("Logout")
             }
         }
     }

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -5,23 +5,43 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.settings.AppSettings
 import gr.eduinvoice.data.settings.SettingsRepository
+import gr.eduinvoice.domain.user.UserUseCases
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import gr.eduinvoice.data.model.User
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val repository: SettingsRepository
+    private val repository: SettingsRepository,
+    private val prefs: UserPreferencesRepository,
+    private val userUseCases: UserUseCases
 ) : ViewModel() {
-    private val _settings = MutableStateFlow(AppSettings())
-    val settings: StateFlow<AppSettings> = _settings.asStateFlow()
+
+    data class SettingsUiState(
+        val settings: AppSettings = AppSettings(),
+        val user: User? = null
+    )
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     init {
         viewModelScope.launch {
-            repository.settings.collectLatest { _settings.value = it }
+            combine(
+                repository.settings,
+                prefs.loggedInUserId.flatMapLatest { id ->
+                    id?.let { userUseCases.getUserProfile(it) } ?: flowOf(null)
+                }
+            ) { settings, user ->
+                SettingsUiState(settings, user)
+            }.collect { _uiState.value = it }
         }
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -37,7 +37,10 @@ fun LoginScreen(
                 title = { Text(stringResource(R.string.login)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
                     }
                 },
                 actions = {

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -38,7 +38,10 @@ fun RegisterScreen(
                 title = { Text(stringResource(R.string.register)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
                     }
                 },
                 actions = {
@@ -84,25 +87,25 @@ fun RegisterScreen(
             OutlinedTextField(
                 value = uiState.subjectSpecialty,
                 onValueChange = viewModel::updateSubjectSpecialty,
-                label = { Text("Subject Specialty") },
+                label = { Text(stringResource(R.string.subject_specialty)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
                 onValueChange = viewModel::updateYearsExperience,
-                label = { Text("Years Experience") },
+                label = { Text(stringResource(R.string.years_experience)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = uiState.subjectSpecialty,
                 onValueChange = viewModel::updateSubjectSpecialty,
-                label = { Text("Subject Specialty") },
+                label = { Text(stringResource(R.string.subject_specialty)) },
                 modifier = Modifier.fillMaxWidth()
             )
             OutlinedTextField(
                 value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
                 onValueChange = viewModel::updateYearsExperience,
-                label = { Text("Years Experience") },
+                label = { Text(stringResource(R.string.years_experience)) },
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,4 +90,18 @@
     <string name="register">Register</string>
     <string name="full_name">Full Name</string>
     <string name="settings">Settings</string>
+
+    <!-- Registration -->
+    <string name="subject_specialty">Subject Specialty</string>
+    <string name="years_experience">Years Experience</string>
+
+    <!-- Settings categories -->
+    <string name="general">General</string>
+    <string name="appearance">Appearance</string>
+    <string name="account">Account</string>
+    <string name="currency">Currency</string>
+    <string name="decimal_places">Decimal places</string>
+    <string name="dark_theme">Dark theme</string>
+    <string name="logout">Logout</string>
+    <string name="switch_account">Switch account</string>
 </resources>


### PR DESCRIPTION
- added user info to settings screen with login/logout handling
- categorized settings into sections and added new strings
- updated SettingsViewModel to expose combined ui state
- replaced hardcoded strings in auth screens
- version bumped to 0.21.7

How to test:
- `./gradlew assemble`
- `./gradlew test` *(fails: network access blocked)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_6882ad84876483308fd46bbde6e93327