### PR TITLE
feat(data): add encrypted backup support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.9] - 2025-08-09
+### Added
+- Backup and restore via Settings screen
+- Encrypted database with SQLCipher
+
 ## [0.21.8] - 2025-08-08
 ### Added
 - Profile screen to edit account details

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ EduInvoice is an Android application for managing tutoring sessions and invoices
 - Generate PDF invoices from selected lessons
 - Monitor revenue and past invoices
 - Theme and preference settings via DataStore
+- Backup and restore your data to JSON
+- SQLCipher-encrypted database
 
 ## Prerequisites
 
 - **JDK 17 or newer** installed and available on your `PATH`.
 - **Android SDK** with API level 35 and build tools. The repository provides a helper script that installs the required SDK packages.
+- SQLCipher native libraries are pulled via Gradle; no manual setup is needed.
 
 ## Mandatory Android SDK setup
 
@@ -48,6 +51,10 @@ in isolation:
 - **app** – Compose UI and navigation.
 - **domain** – business logic and use-cases.
 - **data** – Room database, repositories, DataStore.
+
+## Backup & Migration
+
+Use the Settings screen to export your entire database to a JSON file and restore it later. When upgrading from versions prior to 0.21.9, create a backup first and restore it after updating so the new SQLCipher encrypted database is populated.
 
 ## Database migrations
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.8"
+        versionName "0.21.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
@@ -13,6 +13,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import kotlinx.coroutines.launch
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.R
@@ -30,6 +34,32 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri ->
+        uri?.let {
+            scope.launch {
+                val json = viewModel.exportBackup()
+                context.contentResolver.openOutputStream(it)?.use { out ->
+                    out.write(json.toByteArray())
+                }
+            }
+        }
+    }
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let {
+            scope.launch {
+                context.contentResolver.openInputStream(it)?.use { ins ->
+                    val json = ins.readBytes().decodeToString()
+                    viewModel.restoreBackup(json)
+                }
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -142,6 +172,18 @@ fun SettingsScreen(
                     Button(onClick = onRegister, modifier = Modifier.weight(1f)) {
                         Text(stringResource(R.string.sign_up))
                     }
+                }
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(onClick = { exportLauncher.launch("eduinvoice-backup.json") }, modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.backup_export))
+                }
+                Button(onClick = { importLauncher.launch(arrayOf("application/json")) }, modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.backup_restore))
                 }
             }
 

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.settings.AppSettings
 import gr.eduinvoice.data.settings.SettingsRepository
 import gr.eduinvoice.domain.user.UserUseCases
+import gr.eduinvoice.data.repository.BackupRepository
 import gr.eduinvoice.data.user.UserPreferencesRepository
 import gr.eduinvoice.data.model.User
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +22,8 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     private val repository: SettingsRepository,
     private val prefs: UserPreferencesRepository,
-    private val userUseCases: UserUseCases
+    private val userUseCases: UserUseCases,
+    private val backupRepository: BackupRepository
 ) : ViewModel() {
 
     data class SettingsUiState(
@@ -57,4 +59,9 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { repository.setDarkTheme(enabled) }
     }
 
+    suspend fun exportBackup(): String = backupRepository.exportJson()
+
+    fun restoreBackup(json: String) {
+        viewModelScope.launch { backupRepository.restoreFromJson(json) }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,6 @@
     <string name="switch_account">Switch account</string>
     <string name="profile">Profile</string>
     <string name="edit_profile">Edit Profile</string>
+    <string name="backup_export">Export Backup</string>
+    <string name="backup_restore">Restore Backup</string>
 </resources>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.1.10'
     id 'com.google.devtools.ksp'
     id 'com.google.dagger.hilt.android'
 }
@@ -28,6 +29,9 @@ dependencies {
     implementation "androidx.room:room-runtime:2.7.1"
     implementation "androidx.room:room-ktx:2.7.1"
     ksp "androidx.room:room-compiler:2.7.1"
+
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
+    implementation "net.zetetic:android-database-sqlcipher:4.5.4"
 
     implementation "androidx.datastore:datastore-preferences:1.1.7"
 

--- a/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import net.sqlcipher.database.SQLiteDatabase
+import net.sqlcipher.database.SupportFactory
 import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.dao.StudentDao
@@ -41,13 +43,18 @@ abstract class EduInvoiceDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: EduInvoiceDatabase? = null
 
-        fun getDatabase(context: Context): EduInvoiceDatabase {
+        fun getDatabase(
+            context: Context,
+            passphrase: ByteArray = SQLiteDatabase.getBytes("eduinvoice".toCharArray())
+        ): EduInvoiceDatabase {
             return INSTANCE ?: synchronized(this) {
+                val factory = SupportFactory(passphrase)
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     EduInvoiceDatabase::class.java,
                     DatabaseConstants.DATABASE_NAME
                 )
+                    .openHelperFactory(factory)
                     .fallbackToDestructiveMigration(false)
                     .addMigrations(MIGRATION_12_13)
                     .build()

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import gr.eduinvoice.data.database.EduInvoiceDatabase
+import net.sqlcipher.database.SQLiteDatabase
 import javax.inject.Singleton
 
 @Module
@@ -18,7 +19,8 @@ object DatabaseModule {
     fun provideEduInvoiceDatabase(
         @ApplicationContext context: Context
     ): EduInvoiceDatabase {
-        return EduInvoiceDatabase.getDatabase(context)
+        val passphrase = SQLiteDatabase.getBytes("eduinvoice".toCharArray())
+        return EduInvoiceDatabase.getDatabase(context, passphrase)
     }
 
     // DatabaseModule only provides the Room database instance.

--- a/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
@@ -12,6 +12,8 @@ import gr.eduinvoice.data.repository.StudentRepository
 import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.data.repository.GroupRepository
 import gr.eduinvoice.data.repository.UserRepository
+import gr.eduinvoice.data.repository.BackupRepository
+import gr.eduinvoice.data.database.EduInvoiceDatabase
 import javax.inject.Singleton
 
 @Module
@@ -39,4 +41,8 @@ object RepositoryModule {
         lessonDao: LessonDao,
         groupDao: GroupDao
     ): TutorBillingRepository = TutorBillingRepository(studentDao, lessonDao, groupDao)
+
+    @Provides
+    @Singleton
+    fun provideBackupRepository(db: EduInvoiceDatabase): BackupRepository = BackupRepository(db)
 }

--- a/data/src/main/java/gr/eduinvoice/data/model/GroupStudentCrossRef.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/GroupStudentCrossRef.kt
@@ -2,8 +2,10 @@ package gr.eduinvoice.data.model
 
 import androidx.room.Entity
 import androidx.room.Index
+import kotlinx.serialization.Serializable
 import gr.eduinvoice.data.database.DatabaseConstants
 
+@Serializable
 @Entity(
     tableName = DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE,
     primaryKeys = ["groupId", "studentId"],

--- a/data/src/main/java/gr/eduinvoice/data/model/Lesson.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/Lesson.kt
@@ -6,9 +6,11 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 
+@Serializable
 @Entity(
     tableName = "lessons",
     foreignKeys = [

--- a/data/src/main/java/gr/eduinvoice/data/model/Student.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/Student.kt
@@ -4,7 +4,9 @@ package gr.eduinvoice.data.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
 
+@Serializable
 @Entity(tableName = "students")
 data class Student(
     @PrimaryKey(autoGenerate = true)

--- a/data/src/main/java/gr/eduinvoice/data/model/StudentGroup.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/StudentGroup.kt
@@ -2,8 +2,10 @@ package gr.eduinvoice.data.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
 import gr.eduinvoice.data.database.DatabaseConstants
 
+@Serializable
 @Entity(tableName = DatabaseConstants.GROUPS_TABLE)
 data class StudentGroup(
     @PrimaryKey(autoGenerate = true)

--- a/data/src/main/java/gr/eduinvoice/data/model/User.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/User.kt
@@ -4,8 +4,10 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
 import gr.eduinvoice.data.database.DatabaseConstants
 
+@Serializable
 @Entity(
     tableName = DatabaseConstants.USERS_TABLE,
     indices = [Index(value = ["username"], unique = true)]

--- a/data/src/main/java/gr/eduinvoice/data/repository/BackupRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/BackupRepository.kt
@@ -1,0 +1,104 @@
+package gr.eduinvoice.data.repository
+
+import android.database.Cursor
+import androidx.room.withTransaction
+import gr.eduinvoice.data.database.DatabaseConstants
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.model.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BackupRepository @Inject constructor(
+    private val db: EduInvoiceDatabase
+) {
+    @Serializable
+    data class BackupDump(
+        val students: List<Student>,
+        val lessons: List<Lesson>,
+        val groups: List<StudentGroup>,
+        val crossRefs: List<GroupStudentCrossRef>,
+        val users: List<User>
+    )
+
+    suspend fun exportJson(): String {
+        val readable = db.openHelper.readableDatabase
+        val students = readable.query("SELECT * FROM ${DatabaseConstants.STUDENTS_TABLE}").use { cursor ->
+            generateSequence { if (cursor.moveToNext()) cursor else null }
+                .map { Student(
+                    id = it.getLong(0),
+                    ownerId = it.getLong(1),
+                    name = it.getString(2),
+                    surname = it.getString(3),
+                    parentMobile = it.getString(4),
+                    parentEmail = it.getString(5),
+                    className = it.getString(6),
+                    rate = it.getDouble(7),
+                    rateType = it.getString(8),
+                    isActive = it.getInt(9) == 1
+                ) }.toList()
+        }
+        val lessons = readable.query("SELECT * FROM ${DatabaseConstants.LESSONS_TABLE}").use { c ->
+            generateSequence { if (c.moveToNext()) c else null }
+                .map { Lesson(
+                    id = it.getLong(0),
+                    ownerId = it.getLong(1),
+                    studentId = it.getLong(2),
+                    groupId = if (it.isNull(3)) null else it.getLong(3),
+                    date = it.getString(4),
+                    startTime = it.getString(5),
+                    durationMinutes = it.getInt(6),
+                    notes = it.getString(7),
+                    isPaid = it.getInt(8) == 1,
+                    isInvoiced = it.getInt(9) == 1
+                ) }.toList()
+        }
+        val groups = readable.query("SELECT * FROM ${DatabaseConstants.GROUPS_TABLE}").use { c ->
+            generateSequence { if (c.moveToNext()) c else null }
+                .map { StudentGroup(
+                    id = it.getLong(0),
+                    ownerId = it.getLong(1),
+                    name = it.getString(2)
+                ) }.toList()
+        }
+        val crossRefs = readable.query("SELECT * FROM ${DatabaseConstants.GROUP_STUDENT_CROSS_REF_TABLE}").use { c ->
+            generateSequence { if (c.moveToNext()) c else null }
+                .map { GroupStudentCrossRef(
+                    groupId = it.getLong(0),
+                    studentId = it.getLong(1),
+                    ownerId = it.getLong(2)
+                ) }.toList()
+        }
+        val users = readable.query("SELECT * FROM ${DatabaseConstants.USERS_TABLE}").use { c ->
+            generateSequence { if (c.moveToNext()) c else null }
+                .map { User(
+                    id = it.getLong(0),
+                    username = it.getString(1),
+                    passwordHash = it.getString(2),
+                    fullName = it.getString(3),
+                    subjectSpecialty = it.getString(4),
+                    yearsExperience = it.getInt(5)
+                ) }.toList()
+        }
+        val dump = BackupDump(students, lessons, groups, crossRefs, users)
+        return Json.encodeToString(BackupDump.serializer(), dump)
+    }
+
+    suspend fun restoreFromJson(json: String) {
+        val dump = Json.decodeFromString(BackupDump.serializer(), json)
+        db.withTransaction {
+            db.clearAllTables()
+            val studentDao = db.studentDao()
+            val lessonDao = db.lessonDao()
+            val groupDao = db.groupDao()
+            val userDao = db.userDao()
+            dump.users.forEach { userDao.insert(it) }
+            dump.students.forEach { studentDao.insert(it) }
+            dump.groups.forEach { groupDao.insertGroup(it) }
+            dump.crossRefs.forEach { groupDao.insertCrossRef(it) }
+            dump.lessons.forEach { lessonDao.insert(it) }
+        }
+    }
+}

--- a/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
@@ -1,0 +1,47 @@
+package gr.eduinvoice.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.model.Student
+import gr.eduinvoice.data.repository.BackupRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BackupRepositoryTest {
+    private lateinit var db: EduInvoiceDatabase
+    private lateinit var repo: BackupRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EduInvoiceDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repo = BackupRepository(db)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun exportAndRestoreRoundTrip() = runBlocking {
+        db.studentDao().insert(Student(name = "Test", surname = "", parentMobile = "", className = "A", rate = 10.0))
+        val json = repo.exportJson()
+        db.clearAllTables()
+        repo.restoreFromJson(json)
+        val students = db.studentDao().getAllActiveStudents().first()
+        assertEquals(1, students.size)
+        assertEquals("Test", students.first().name)
+    }
+}


### PR DESCRIPTION
## Summary
- enable JSON backup repository for all tables
- expose backup options in settings UI
- document backup & encryption in README
- integrate SQLCipher and configure `EduInvoiceDatabase`
- mark Room entities `@Serializable`

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: Unable to download Robolectric dependencies)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_6882bfbbbbd08330a5b754cde48b3912