### PR TITLE
fix(test): remove unused import causing build failure

### DIFF
--- a/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
@@ -3,7 +3,6 @@ package gr.eduinvoice.ui.invoice
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4


### PR DESCRIPTION
## Summary
- remove obsolete `onAllNodes` import from `InvoiceScreenTest`

## Testing
- `./gradlew clean` *(passes)*
- `./gradlew assemble` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836e13f0b083309c6bb31fbd071f6d