### PR TITLE
fix: retain group id when editing lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.15] - 2025-08-15
+### Fix
+- Preserve group ID when editing group lessons and update navigation.
+
 ## [0.21.14] - 2025-08-14
 ### Docs
 - Restructured CHANGELOG into themed sub-sections.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.14"
+        versionName "0.21.15"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -131,7 +131,7 @@ class StudentScreenTest {
             StudentScreen(
                 studentId = "1",
                 onNavigateBack = {},
-                onNavigateToLesson = {},
+                onNavigateToLesson = { _, _ -> },
                 onAddLesson = {},
                 viewModel = viewModel
             )

--- a/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
+++ b/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
@@ -10,9 +10,9 @@ sealed class Screen(val route: String) {
         fun createRoute(studentId: Long) = "student/$studentId"
     }
     object Lessons : Screen("lessons")
-    object Lesson : Screen("lesson/{lessonId}?studentId={studentId}") {
-        fun createRoute(lessonId: Long, studentId: Long = 0L) =
-            "lesson/$lessonId?studentId=$studentId"
+    object Lesson : Screen("lesson/{lessonId}?studentId={studentId}&groupId={groupId}") {
+        fun createRoute(lessonId: Long, studentId: Long = 0L, groupId: Long = 0L) =
+            "lesson/$lessonId?studentId=$studentId&groupId=$groupId"
     }
     object Classes : Screen("classes")
     object Revenue : Screen("revenue")

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -123,9 +123,9 @@ fun TutorBillingApp() {
         composable(Screen.Lessons.route) {
             LessonsScreen(
                 onBack = { navController.popBackStack() },
-                onLessonClick = { studentId, lessonId ->
+                onLessonClick = { studentId, lessonId, groupId ->
                     navController.navigate(
-                        Screen.Lesson.createRoute(lessonId, studentId)
+                        Screen.Lesson.createRoute(lessonId, studentId, groupId)
                     )
                 },
                 onAddLesson = { navController.navigate(Screen.Lesson.createRoute(0)) },
@@ -209,6 +209,10 @@ fun TutorBillingApp() {
                 navArgument("studentId") {
                     type = NavType.LongType
                     defaultValue = 0L
+                },
+                navArgument("groupId") {
+                    type = NavType.LongType
+                    defaultValue = 0L
                 }
             )
         ) { backStackEntry ->
@@ -217,6 +221,7 @@ fun TutorBillingApp() {
             val lessonId = backStackEntry.arguments?.getLong("lessonId") ?: 0L
 
             val studentId = backStackEntry.arguments?.getLong("studentId") ?: 0L
+            val groupId = backStackEntry.arguments?.getLong("groupId") ?: 0L
 
             LaunchedEffect(Unit) {
                 viewModel.setNavigationCallback {

--- a/app/src/main/java/gr/eduinvoice/navigation/StudentNavGraph.kt
+++ b/app/src/main/java/gr/eduinvoice/navigation/StudentNavGraph.kt
@@ -51,9 +51,9 @@ fun NavGraphBuilder.studentGraph(navController: NavHostController) {
             StudentScreen(
                 studentId = studentId,
                 onNavigateBack = { navController.popBackStack() },
-                onNavigateToLesson = { lessonId ->
+                onNavigateToLesson = { lessonId, groupId ->
                     navController.navigate(
-                        Screen.Lesson.createRoute(lessonId, studentIdArg)
+                        Screen.Lesson.createRoute(lessonId, studentIdArg, groupId)
                     )
                 },
                 onAddLesson = {

--- a/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
@@ -101,7 +101,9 @@ class LessonViewModel @Inject constructor(
                                 durationMinutes = l.durationMinutes.toString(),
                                 notes = l.notes ?: "",
                                 isEditMode = false,
-                                isPaid = l.isPaid
+                                isPaid = l.isPaid,
+                                selectedGroupId = l.groupId,
+                                isGroupLesson = l.groupId != null
                             )
                         }
                     }

--- a/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsScreen.kt
@@ -30,7 +30,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun LessonsScreen(
     onBack: () -> Unit,
-    onLessonClick: (Long, Long) -> Unit,
+    onLessonClick: (Long, Long, Long) -> Unit,
     onAddLesson: () -> Unit,
     onInvoice: (Long?) -> Unit,
     onPastInvoices: () -> Unit,
@@ -97,7 +97,7 @@ fun LessonsScreen(
                     items(lessons, key = { it.lesson.id }) { item ->
                         LessonItem(
                             lessonWithStudent = item,
-                            onClick = { onLessonClick(item.student.id, item.lesson.id) },
+                            onClick = { onLessonClick(item.student.id, item.lesson.id, item.lesson.groupId ?: 0L) },
                             onPaidChange = { viewModel.updatePaid(item.lesson.id, it) }
                         )
                         HorizontalDivider()

--- a/app/src/main/java/gr/eduinvoice/ui/student/StudentScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/student/StudentScreen.kt
@@ -42,7 +42,7 @@ import java.time.format.DateTimeFormatter
 fun StudentScreen(
     studentId: String?,
     onNavigateBack: () -> Unit,
-    onNavigateToLesson: (Long) -> Unit,
+    onNavigateToLesson: (Long, Long) -> Unit,
     onAddLesson: () -> Unit,
     viewModel: StudentViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
@@ -165,7 +165,7 @@ private fun StudentMetricsRow(uiState: StudentUiState, modifier: Modifier = Modi
 private fun StudentDetailView(
     uiState: StudentUiState,
     viewModel: StudentViewModel,
-    onLessonClick: (Long) -> Unit,
+    onLessonClick: (Long, Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -236,7 +236,7 @@ private fun StudentDetailView(
                 LessonCard(
                     lesson = lesson,
                     fee = fee,
-                    onLessonClick = { onLessonClick(lesson.id) },
+                    onLessonClick = { onLessonClick(lesson.id, lesson.groupId ?: 0L) },
                     onDeleteClick = { viewModel.deleteLesson(lesson.id) }
                 )
                 HorizontalDivider()

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
@@ -126,6 +126,32 @@ class LessonViewModelGroupTest {
         assertEquals(setOf(1L, 2L), lessonFlow.value.map { it.studentId }.toSet())
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun loadExistingGroupLessonPopulatesState() = runTest {
+        val lesson = Lesson(
+            id = 1,
+            studentId = 1,
+            groupId = 2,
+            date = "2024-01-01",
+            startTime = "10:00",
+            durationMinutes = 60
+        )
+        lessonFlow.value = listOf(lesson)
+        groupFlow.value = listOf(StudentGroup(id = 2, name = "G2"))
+
+        val vm = LessonViewModel(
+            SavedStateHandle(mapOf("lessonId" to 1L)),
+            lessonUseCases,
+            studentUseCases,
+            groupUseCases
+        )
+        advanceUntilIdle()
+
+        assertEquals(2L, vm.uiState.value.selectedGroupId)
+        assertEquals(true, vm.uiState.value.isGroupLesson)
+    }
+
     class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
         override suspend fun insert(student: Student): Long {
             flow.value = flow.value + student

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -91,7 +91,7 @@ class LessonsScreenTest {
         )
         val vm = LessonsViewModel(lessonUseCases)
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
+            LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         val header1 = composeRule.onNodeWithTag("header_1").fetchSemanticsNode().positionInRoot.y
@@ -121,7 +121,7 @@ class LessonsScreenTest {
         val vm = LessonsViewModel(lessonUseCases)
         var clicked = false
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
+            LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("10:00 • 60 min").performClick()


### PR DESCRIPTION
- populate group info in LessonViewModel.loadLesson
- carry groupId in navigation routes and screens
- added regression test for editing group lessons

`./gradlew test` (fails: network blocked)
`./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_6884bd880ea4833084eb31af8d7dc919