### PR TITLE
fix(build): remove duplicate crashlytics dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.17] - 2025-08-17
+### Build/CI
+- Remove duplicate Crashlytics dependency entry.
+
 ## [0.21.16] - 2025-08-16
 ### Build/CI
 - Enable code shrinking and resource shrinking in release builds.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.16"
+        versionName "0.21.17"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -99,8 +99,7 @@ android {
     implementation "androidx.compose.material:material-icons-core"
     implementation "androidx.compose.material:material-icons-extended"
     implementation "androidx.compose.foundation:foundation"
-        implementation 'com.google.firebase:firebase-crashlytics:19.4.4'
-        debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling"
     debugImplementation "androidx.compose.ui:ui-test-manifest"
 
     // Lifecycle


### PR DESCRIPTION
- WHAT changed
  - Removed duplicated dependency in `app/build.gradle`
  - Bumped version to 0.21.17 and updated changelog
- WHY it matters
  - Avoids redundant package declarations
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_6884cdeb846083308e8eb263d4d752ba