### PR TITLE
fix(studentcard): show rate suffix by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.18] - 2025-08-18
+### Fix
+- Display the correct rate suffix in `StudentCard` based on `rateType`.
+### Test
+- Added Compose tests verifying the rate label for both rate types.
+
 ## [0.21.17] - 2025-08-17
 ### Build/CI
 - Remove duplicate Crashlytics dependency entry.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.17"
+        versionName "0.21.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/components/StudentCard.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/components/StudentCard.kt
@@ -16,6 +16,7 @@ import gr.eduinvoice.ui.design.AppColors
 import androidx.compose.ui.res.stringResource
 import gr.eduinvoice.R
 import gr.eduinvoice.data.model.StudentWithEarnings
+import gr.eduinvoice.data.model.RateTypes
 import gr.eduinvoice.utils.getFullName
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,8 +52,9 @@ fun StudentCard(
                     fontWeight = FontWeight.Bold
                 )
 
+                val rateLabel = if (studentWithEarnings.student.rateType == RateTypes.PER_LESSON) "lesson" else "hour"
                 Text(
-                    text = "€${studentWithEarnings.student.rate}/hour",
+                    text = "€${studentWithEarnings.student.rate}/$rateLabel",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/test/java/gr/eduinvoice/ui/components/StudentCardTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/components/StudentCardTest.kt
@@ -1,0 +1,45 @@
+package gr.eduinvoice.ui.components
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import gr.eduinvoice.data.model.Student
+import gr.eduinvoice.data.model.RateTypes
+import gr.eduinvoice.data.model.StudentWithEarnings
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StudentCardTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun baseStudent(rateType: String) = Student(
+        id = 1,
+        name = "Alice",
+        surname = "",
+        parentMobile = "",
+        className = "",
+        rate = 10.0,
+        rateType = rateType
+    )
+
+    @Test
+    fun hourlyRateShowsCorrectLabel() {
+        val student = StudentWithEarnings(baseStudent(RateTypes.HOURLY), 0.0, 0.0)
+        composeRule.setContent {
+            StudentCard(student, onStudentClick = {}, onDeleteClick = {})
+        }
+        composeRule.onNodeWithText("€10.0/hour").assertExists()
+    }
+
+    @Test
+    fun perLessonRateShowsCorrectLabel() {
+        val student = StudentWithEarnings(baseStudent(RateTypes.PER_LESSON), 0.0, 0.0)
+        composeRule.setContent {
+            StudentCard(student, onStudentClick = {}, onDeleteClick = {})
+        }
+        composeRule.onNodeWithText("€10.0/lesson").assertExists()
+    }
+}


### PR DESCRIPTION
- WHAT changed
  - StudentCard now shows €/lesson when rateType is PER_LESSON
  - Added StudentCardTest verifying both rateType labels
  - Bump versionName and update CHANGELOG
- WHY it matters
  - Properly reflects tutor rate scheme in UI
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_6884cdcee8208330987feafa5c6274a0