### PR TITLE
fix(register): clean up duplicate fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.18] - 2025-08-18
+### UI/Design
+- Remove duplicate input fields on Register screen.
+
 ## [0.21.17] - 2025-08-17
 ### Build/CI
 - Remove duplicate Crashlytics dependency entry.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.17"
+        versionName "0.21.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -101,20 +101,8 @@ fun RegisterScreen(
                 value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
                 onValueChange = viewModel::updateYearsExperience,
                 label = { Text(stringResource(R.string.years_experience)) },
-                modifier = Modifier.fillMaxWidth()
-            )
-            OutlinedTextField(
-                value = uiState.subjectSpecialty,
-                onValueChange = viewModel::updateSubjectSpecialty,
-                label = { Text(stringResource(R.string.subject_specialty)) },
-                modifier = Modifier.fillMaxWidth()
-            )
-            OutlinedTextField(
-                value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
-                onValueChange = viewModel::updateYearsExperience,
-                label = { Text(stringResource(R.string.years_experience)) },
                 modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             )
             OutlinedTextField(
                 value = uiState.password,


### PR DESCRIPTION
- remove duplicated subjectSpecialty and yearsExperience inputs
- keep numeric keyboard on remaining yearsExperience field
- bump version to 0.21.18 and document change

`./gradlew assembleDebug` succeeded but `./gradlew test` failed in this environment

------
https://chatgpt.com/codex/tasks/task_e_6884cdc331588330b75f128b1d58821f