### PR TITLE
feat(groups): store cross-ref owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.18] - 2025-08-18
+### Database/Room
+- Group-student cross-refs now store the owning user ID.
+
 ## [0.21.17] - 2025-08-17
 ### Build/CI
 - Remove duplicate Crashlytics dependency entry.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.17"
+        versionName "0.21.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupScreen.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.*
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.user.SessionViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -21,6 +22,8 @@ fun GroupScreen(
     viewModel: GroupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val sessionViewModel: SessionViewModel = hiltViewModel()
+    val userId by sessionViewModel.currentUserId.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -32,7 +35,7 @@ fun GroupScreen(
                     }
                 },
                 actions = {
-                    TextButton(onClick = { viewModel.saveGroup(); onBack() }) {
+                    TextButton(onClick = { viewModel.saveGroup(userId ?: 0L); onBack() }) {
                         Text("Save")
                     }
                 }

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
@@ -53,7 +53,7 @@ class GroupViewModel @Inject constructor(
         )
     }
 
-    fun saveGroup() {
+    fun saveGroup(userId: Long) {
         viewModelScope.launch {
             val state = _uiState.value
             val group = StudentGroup(id = groupId, name = state.name)
@@ -65,7 +65,7 @@ class GroupViewModel @Inject constructor(
             val selected = state.students.filter { it.selected }.map { it.id }.toSet()
             val toAdd = selected - originalStudents
             val toRemove = originalStudents - selected
-            toAdd.forEach { groupUseCases.addStudentToGroup(id, it) }
+            toAdd.forEach { groupUseCases.addStudentToGroup(id, it, userId) }
             toRemove.forEach { groupUseCases.removeStudentFromGroup(id, it) }
         }
     }

--- a/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
@@ -33,7 +33,7 @@ class GroupViewModelTest {
 
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val groupFlow = MutableStateFlow<List<StudentGroup>>(emptyList())
-    private val relations = mutableMapOf<Long, MutableList<Long>>()
+    private val relations = mutableMapOf<Long, MutableMap<Long, Long>>()
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val groupDao = FakeGroupDao(groupFlow, studentFlow, relations)
@@ -91,11 +91,11 @@ class GroupViewModelTest {
         vm.updateName("Group A")
         vm.toggleStudent(1)
         vm.toggleStudent(2)
-        vm.saveGroup()
+        vm.saveGroup(5)
         advanceUntilIdle()
 
         assertEquals(1, groupFlow.value.size)
-        assertEquals(setOf(1L, 2L), relations[1L]?.toSet())
+        assertEquals(mapOf(1L to 5L, 2L to 5L), relations[1L])
     }
 
     class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
@@ -117,8 +117,8 @@ class GroupViewModelTest {
 
     class FakeGroupDao(
         private val groups: MutableStateFlow<List<StudentGroup>>, 
-        private val students: MutableStateFlow<List<Student>>, 
-        private val refs: MutableMap<Long, MutableList<Long>>
+        private val students: MutableStateFlow<List<Student>>,
+        private val refs: MutableMap<Long, MutableMap<Long, Long>>
     ) : GroupDao {
         override suspend fun insertGroup(group: StudentGroup): Long {
             val id = if (group.id == 0L) (groups.value.maxOfOrNull { it.id } ?: 0L) + 1 else group.id
@@ -135,15 +135,13 @@ class GroupViewModelTest {
         override fun getAllGroups(userId: Long): Flow<List<StudentGroup>> = groups.asStateFlow()
         override fun getGroupById(id: Long, userId: Long): Flow<StudentGroup?> = groups.map { list -> list.find { it.id == id } }
         override suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) {
-            refs.getOrPut(crossRef.groupId) { mutableListOf() }.apply {
-                if (!contains(crossRef.studentId)) add(crossRef.studentId)
-            }
+            refs.getOrPut(crossRef.groupId) { mutableMapOf() }[crossRef.studentId] = crossRef.ownerId
         }
         override suspend fun deleteCrossRef(groupId: Long, studentId: Long, userId: Long) {
             refs[groupId]?.remove(studentId)
         }
         override fun getStudentsForGroup(groupId: Long, userId: Long): Flow<List<Student>> = students.map { list ->
-            val ids = refs[groupId] ?: emptyList<Long>()
+            val ids = refs[groupId]?.filter { it.value == userId }?.keys ?: emptySet()
             list.filter { it.id in ids }
         }
     }

--- a/data/src/test/java/gr/eduinvoice/data/GroupDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/GroupDaoTest.kt
@@ -42,10 +42,19 @@ class GroupDaoTest {
 
     @Test
     fun insertGroupAndStudents() = runBlocking {
-        val groupId = groupDao.insertGroup(StudentGroup(name = "Group A"))
-        val studentId = studentDao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
-        groupDao.insertCrossRef(GroupStudentCrossRef(groupId = groupId, studentId = studentId))
-        val students = groupDao.getStudentsForGroup(groupId).first()
+        val groupId = groupDao.insertGroup(StudentGroup(name = "Group A", ownerId = 7))
+        val studentId = studentDao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0, ownerId = 7))
+        groupDao.insertCrossRef(GroupStudentCrossRef(groupId = groupId, studentId = studentId, ownerId = 7))
+
+        db.openHelper.readableDatabase.query(
+            "SELECT ownerId FROM group_student_cross_ref WHERE groupId = ? AND studentId = ?",
+            arrayOf(groupId.toString(), studentId.toString())
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(7L, cursor.getLong(0))
+        }
+
+        val students = groupDao.getStudentsForGroup(groupId, 7).first()
         assertEquals(1, students.size)
         assertEquals(studentId, students.first().id)
     }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/group/AddStudentToGroup.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/group/AddStudentToGroup.kt
@@ -7,6 +7,6 @@ import javax.inject.Inject
 class AddStudentToGroup @Inject constructor(
     private val repository: GroupRepository
 ) {
-    suspend operator fun invoke(groupId: Long, studentId: Long) =
-        repository.insertCrossRef(GroupStudentCrossRef(groupId, studentId))
+    suspend operator fun invoke(groupId: Long, studentId: Long, userId: Long = 0) =
+        repository.insertCrossRef(GroupStudentCrossRef(groupId, studentId, userId))
 }


### PR DESCRIPTION
- WHAT changed
  - Add `userId` parameter to `AddStudentToGroup`
  - Propagate user id through `GroupViewModel` and `GroupScreen`
  - Update tests to verify cross-ref ownerId
  - Bump version and changelog
- WHY it matters
  - Ensures group–student relations are tied to the correct account
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_6884cdd77f648330bb580a740a17d9c5