### PR TITLE
feat(welcome): redesign welcome screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.19] - 2025-08-19
+### UI/Design
+- Redesigned Welcome screen with floating settings button and solid buttons.
+- Added copyright notice.
+
 ## [0.21.18] - 2025-08-18
 ### Database/Room
 - Group-student cross-refs now store the owning user ID.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.18"
+        versionName "0.21.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import gr.eduinvoice.R
-import gr.eduinvoice.ui.design.AppColors
-import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,15 +25,10 @@ fun WelcomeScreen(
     onSettings: () -> Unit,
 ) {
     Scaffold(
-        topBar = {
-            AppTopBar(
-                title = stringResource(R.string.app_name),
-                actions = {
-                    IconButton(onClick = onSettings) {
-                        Icon(Icons.Default.Settings, contentDescription = "Settings")
-                    }
-                }
-            )
+        floatingActionButton = {
+            FloatingActionButton(onClick = onSettings, containerColor = MaterialTheme.colorScheme.tertiary) {
+                Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings))
+            }
         }
     ) { padding ->
         AnimatedVisibility(
@@ -70,15 +63,20 @@ fun WelcomeScreen(
                 Button(
                     onClick = onSignIn,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.primaryContainer)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) { Text(stringResource(R.string.sign_in)) }
                 Button(
                     onClick = onSignUp,
                     modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(containerColor = AppColors.secondaryContainer)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
                 ) { Text(stringResource(R.string.sign_up)) }
             }
             Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = stringResource(R.string.copyright_notice),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
         }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,9 @@
     <string name="welcome_message">Welcome to EduInvoice</string>
     <string name="sign_in">Sign In</string>
     <string name="sign_up">Sign Up</string>
+
+    <!-- Copyright -->
+    <string name="copyright_notice">© 2025 EduInvoice. All rights reserved.</string>
     
     <!-- Authentication -->
     <string name="username">Username</string>


### PR DESCRIPTION
## Summary
- remove Welcome top bar and add floating settings button
- use theme colors for sign in/sign up buttons
- display copyright on the Welcome screen
- bump version to 0.21.19 and document changes

## Testing
- `./gradlew clean assemble test lintDebug` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884d669a35083308dcd8d9f0e7ac57d