### PR TITLE
feat(domain,data): require user ID in lesson queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.21] - 2025-08-21
+### Domain
+- Lesson use cases now take `userId` when fetching or adding lessons.
+### Data
+- `TutorBillingRepository` and `LessonDao` require explicit user IDs.
+
 ## [0.21.20] - 2025-08-20
 ### Domain
 - Use cases now accept a `userId` parameter for student and group queries.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.20"
+        versionName "0.21.21"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
+++ b/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
@@ -20,25 +20,25 @@ interface LessonDao {
     suspend fun deleteById(lessonId: Long)
 
     @Query("SELECT * FROM lessons WHERE id = :lessonId AND ownerId = :userId")
-    fun getLessonById(lessonId: Long, userId: Long = 0): Flow<Lesson?>
+    fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?>
 
     @Query("SELECT * FROM lessons WHERE studentId = :studentId AND ownerId = :userId ORDER BY date DESC, startTime DESC")
-    fun getLessonsByStudentId(studentId: Long, userId: Long = 0): Flow<List<Lesson>>
+    fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>>
 
     @Query("SELECT * FROM lessons WHERE ownerId = :userId ORDER BY date DESC, startTime DESC")
-    fun getAllLessons(userId: Long = 0): Flow<List<Lesson>>
+    fun getAllLessons(userId: Long): Flow<List<Lesson>>
 
     @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate AND ownerId = :userId ORDER BY date DESC, startTime DESC")
-    fun getLessonsInDateRange(startDate: String, endDate: String, userId: Long = 0): Flow<List<Lesson>>
+    fun getLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>>
 
     @Query("SELECT * FROM lessons WHERE studentId = :studentId AND date BETWEEN :startDate AND :endDate AND ownerId = :userId ORDER BY date ASC")
-    fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long = 0): Flow<List<Lesson>>
+    fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>>
 
     @Query("SELECT * FROM lessons WHERE studentId = :studentId AND date BETWEEN :startDate AND :endDate AND isPaid = 0 AND ownerId = :userId ORDER BY date ASC")
-    fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long = 0): Flow<List<Lesson>>
+    fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>>
 
     @Query("SELECT * FROM lessons WHERE date BETWEEN :startDate AND :endDate AND isPaid = 0 AND ownerId = :userId ORDER BY date ASC")
-    fun getUnpaidLessonsInDateRange(startDate: String, endDate: String, userId: Long = 0): Flow<List<Lesson>>
+    fun getUnpaidLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>>
 
     @Query("UPDATE lessons SET isPaid = :paid WHERE id IN (:ids)")
     suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean)
@@ -47,7 +47,7 @@ interface LessonDao {
     suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean)
 
     @Query("SELECT isInvoiced FROM lessons WHERE id = :lessonId AND ownerId = :userId")
-    fun isLessonInvoiced(lessonId: Long, userId: Long = 0): Flow<Boolean?>
+    fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?>
 
     @Transaction
     @Query(
@@ -77,7 +77,7 @@ interface LessonDao {
         ORDER BY lessons.date DESC, lessons.startTime DESC
         """
     )
-    fun getLessonsWithStudents(userId: Long = 0): Flow<List<LessonWithStudent>>
+    fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>>
 
     @Transaction
     @Query(
@@ -107,7 +107,7 @@ interface LessonDao {
         ORDER BY lessons.date DESC, lessons.startTime DESC
         """
     )
-    fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long = 0): Flow<List<LessonWithStudent>>
+    fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>>
 
     @Transaction
     @Query(
@@ -137,7 +137,7 @@ interface LessonDao {
         ORDER BY lessons.date DESC, lessons.startTime DESC
         """
     )
-    fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long = 0): Flow<List<LessonWithStudent>>
+    fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>>
 
     @Transaction
     @Query(
@@ -167,5 +167,5 @@ interface LessonDao {
         ORDER BY lessons.date DESC, lessons.startTime DESC
         """
     )
-    fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long = 0): Flow<List<LessonWithStudent>>
+    fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>>
 }

--- a/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
@@ -66,15 +66,15 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Gets a single student by ID.
      */
-    suspend fun getStudent(studentId: Long): Student? {
-        return studentDao.getStudentById(studentId, 0).first()
+    suspend fun getStudent(studentId: Long, userId: Long): Student? {
+        return studentDao.getStudentById(studentId, userId).first()
     }
 
     /**
      * Gets all active students as a Flow.
      */
-    fun getAllActiveStudents(): Flow<List<Student>> {
-        return studentDao.getAllActiveStudents(0)
+    fun getAllActiveStudents(userId: Long): Flow<List<Student>> {
+        return studentDao.getAllActiveStudents(userId)
     }
 
     // ===== Lesson Operations =====
@@ -87,17 +87,17 @@ class TutorBillingRepository @Inject constructor(
      * @throws IllegalArgumentException if data is invalid
      * @throws IllegalStateException if student doesn't exist or is inactive
      */
-    suspend fun addLesson(lesson: Lesson): Long {
+    suspend fun addLesson(lesson: Lesson, userId: Long): Long {
         require(lesson.durationMinutes > 0) { "Lesson duration must be positive" }
-        val student = studentDao.getStudentById(lesson.studentId, 0).first()
+        val student = studentDao.getStudentById(lesson.studentId, userId).first()
         checkNotNull(student) { "Cannot add lesson for a non-existent student" }
         check(student.isActive) { "Cannot add lesson for an inactive student" }
         return lessonDao.insert(lesson)
     }
 
-    suspend fun addGroupLesson(groupId: Long, lesson: Lesson): List<Long> {
+    suspend fun addGroupLesson(groupId: Long, lesson: Lesson, userId: Long): List<Long> {
         require(lesson.durationMinutes > 0) { "Lesson duration must be positive" }
-        val students = groupDao.getStudentsForGroup(groupId, 0).first()
+        val students = groupDao.getStudentsForGroup(groupId, userId).first()
         return students.map { student ->
             lessonDao.insert(
                 lesson.copy(
@@ -126,15 +126,15 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Gets all lessons for a specific student as a Flow.
      */
-    fun getLessonsForStudent(studentId: Long): Flow<List<Lesson>> {
-        return lessonDao.getLessonsByStudentId(studentId)
+    fun getLessonsForStudent(studentId: Long, userId: Long): Flow<List<Lesson>> {
+        return lessonDao.getLessonsByStudentId(studentId, userId)
     }
 
     /**
      * Gets lessons with full student data for a specific student.
      */
-    fun getLessonsWithStudentData(studentId: Long): Flow<List<LessonWithStudent>> {
-        return lessonDao.getLessonsWithStudentsByStudent(studentId)
+    fun getLessonsWithStudentData(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> {
+        return lessonDao.getLessonsWithStudentsByStudent(studentId, userId)
     }
 
     // ===== Financial Calculations =====
@@ -152,7 +152,7 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Emits a list of [StudentFinancialSummary], one per active student.
      */
-    fun getStudentFinancialSummaries(): Flow<List<StudentFinancialSummary>> {
+    fun getStudentFinancialSummaries(userId: Long): Flow<List<StudentFinancialSummary>> {
         val today = LocalDate.now()
         val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
         val weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
@@ -160,8 +160,8 @@ class TutorBillingRepository @Inject constructor(
         val monthEnd = today.withDayOfMonth(today.lengthOfMonth())
 
         return combine(
-            studentDao.getAllActiveStudents(0),
-            lessonDao.getAllLessons()
+            studentDao.getAllActiveStudents(userId),
+            lessonDao.getAllLessons(userId)
         ) { students, lessons ->
             students.map { student ->
                 val studentLessons = lessons.filter { it.studentId == student.id }
@@ -188,10 +188,10 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Gets total earnings across all students for a given date range.
      */
-    fun getTotalEarningsForDateRange(startDate: LocalDate, endDate: LocalDate): Flow<Double> {
+    fun getTotalEarningsForDateRange(startDate: LocalDate, endDate: LocalDate, userId: Long): Flow<Double> {
         return combine(
-            lessonDao.getLessonsInDateRange(startDate.toString(), endDate.toString()),
-            studentDao.getAllActiveStudents(0)
+            lessonDao.getLessonsInDateRange(startDate.toString(), endDate.toString(), userId),
+            studentDao.getAllActiveStudents(userId)
         ) { lessons, students ->
             val studentMap = students.associateBy { it.id }
             lessons.sumOf { lesson ->
@@ -216,9 +216,9 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Generates a detailed report for a single student.
      */
-    suspend fun getStudentDetailedReport(studentId: Long): StudentDetailedReport? {
-        val student = studentDao.getStudentById(studentId, 0).first() ?: return null
-        val lessons: List<Lesson> = lessonDao.getLessonsByStudentId(studentId).first()
+    suspend fun getStudentDetailedReport(studentId: Long, userId: Long): StudentDetailedReport? {
+        val student = studentDao.getStudentById(studentId, userId).first() ?: return null
+        val lessons: List<Lesson> = lessonDao.getLessonsByStudentId(studentId, userId).first()
         val totalMinutes = lessons.sumOf { it.durationMinutes }
         val totalHours = totalMinutes / 60.0
         val totalEarnings = lessons.sumOf { it.calculateFee(student) }

--- a/data/src/test/java/gr/eduinvoice/data/LessonDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/LessonDaoTest.kt
@@ -43,7 +43,7 @@ class LessonDaoTest {
     fun insertAndQueryLessonsByStudent() = runBlocking {
         val studentId = studentDao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "A", rate = 10.0))
         lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-01", startTime = "10:00", durationMinutes = 60))
-        val lessons = lessonDao.getLessonsByStudentId(studentId).first()
+        val lessons = lessonDao.getLessonsByStudentId(studentId, 0).first()
         assertEquals(1, lessons.size)
         assertEquals(studentId, lessons.first().studentId)
     }
@@ -53,7 +53,7 @@ class LessonDaoTest {
         val studentId = studentDao.insert(Student(name = "Bob", surname = "", parentMobile = "", className = "B", rate = 15.0))
         val id = lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-02", startTime = "11:00", durationMinutes = 90))
         lessonDao.updatePaidStatus(listOf(id), true)
-        val lesson = lessonDao.getLessonById(id).first()
+        val lesson = lessonDao.getLessonById(id, 0).first()
         assertEquals(true, lesson?.isPaid)
     }
 
@@ -62,7 +62,7 @@ class LessonDaoTest {
         val studentId = studentDao.insert(Student(name = "Cara", surname = "", parentMobile = "", className = "C", rate = 12.0))
         val id = lessonDao.insert(Lesson(studentId = studentId, date = "2024-01-03", startTime = "12:00", durationMinutes = 60))
         lessonDao.updateInvoicedStatus(listOf(id), true)
-        val invoiced = lessonDao.isLessonInvoiced(id).first()
+        val invoiced = lessonDao.isLessonInvoiced(id, 0).first()
         assertEquals(true, invoiced)
     }
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/AddGroupLesson.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/AddGroupLesson.kt
@@ -7,6 +7,6 @@ import javax.inject.Inject
 class AddGroupLesson @Inject constructor(
     private val repository: TutorBillingRepository
 ) {
-    suspend operator fun invoke(groupId: Long, lesson: Lesson): List<Long> =
-        repository.addGroupLesson(groupId, lesson)
+    suspend operator fun invoke(groupId: Long, lesson: Lesson, userId: Long = 0): List<Long> =
+        repository.addGroupLesson(groupId, lesson, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/AddLesson.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/AddLesson.kt
@@ -7,5 +7,6 @@ import javax.inject.Inject
 class AddLesson @Inject constructor(
     private val repository: TutorBillingRepository
 ) {
-    suspend operator fun invoke(lesson: Lesson): Long = repository.addLesson(lesson)
+    suspend operator fun invoke(lesson: Lesson, userId: Long = 0): Long =
+        repository.addLesson(lesson, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetAllLessons.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetAllLessons.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetAllLessons @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(): Flow<List<Lesson>> = dao.getAllLessons()
+    operator fun invoke(userId: Long = 0): Flow<List<Lesson>> = dao.getAllLessons(userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonById.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonById.kt
@@ -8,5 +8,5 @@ import javax.inject.Inject
 class GetLessonById @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(id: Long): Flow<Lesson?> = dao.getLessonById(id)
+    operator fun invoke(id: Long, userId: Long = 0): Flow<Lesson?> = dao.getLessonById(id, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsByStudentId.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsByStudentId.kt
@@ -8,5 +8,6 @@ import javax.inject.Inject
 class GetLessonsByStudentId @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(id: Long): Flow<List<Lesson>> = dao.getLessonsByStudentId(id)
+    operator fun invoke(id: Long, userId: Long = 0): Flow<List<Lesson>> =
+        dao.getLessonsByStudentId(id, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsWithStudents.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsWithStudents.kt
@@ -8,5 +8,6 @@ import javax.inject.Inject
 class GetLessonsWithStudents @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(): Flow<List<LessonWithStudent>> = dao.getLessonsWithStudents()
+    operator fun invoke(userId: Long = 0): Flow<List<LessonWithStudent>> =
+        dao.getLessonsWithStudents(userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsWithStudentsByStudentAndDateRange.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetLessonsWithStudentsByStudentAndDateRange.kt
@@ -8,6 +8,11 @@ import javax.inject.Inject
 class GetLessonsWithStudentsByStudentAndDateRange @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(studentId: Long, start: String, end: String): Flow<List<LessonWithStudent>> =
-        dao.getLessonsWithStudentsByStudentAndDateRange(studentId, start, end)
+    operator fun invoke(
+        studentId: Long,
+        start: String,
+        end: String,
+        userId: Long = 0
+    ): Flow<List<LessonWithStudent>> =
+        dao.getLessonsWithStudentsByStudentAndDateRange(studentId, start, end, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetStudentLessons.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/GetStudentLessons.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class GetStudentLessons @Inject constructor(
     private val repository: TutorBillingRepository
 ) {
-    operator fun invoke(studentId: Long): Flow<List<Lesson>> =
-        repository.getLessonsForStudent(studentId)
+    operator fun invoke(studentId: Long, userId: Long = 0): Flow<List<Lesson>> =
+        repository.getLessonsForStudent(studentId, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/IsLessonInvoiced.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/IsLessonInvoiced.kt
@@ -7,5 +7,6 @@ import javax.inject.Inject
 class IsLessonInvoiced @Inject constructor(
     private val dao: LessonDao
 ) {
-    operator fun invoke(id: Long): Flow<Boolean?> = dao.isLessonInvoiced(id)
+    operator fun invoke(id: Long, userId: Long = 0): Flow<Boolean?> =
+        dao.isLessonInvoiced(id, userId)
 }

--- a/domain/src/test/java/gr/eduinvoice/domain/lesson/AddGroupLessonIntegrationTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/lesson/AddGroupLessonIntegrationTest.kt
@@ -40,18 +40,23 @@ class AddGroupLessonIntegrationTest {
 
     @Test
     fun addsLessonForEachStudentInGroup() = runBlocking {
-        val s1 = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
-        val s2 = db.studentDao().insert(Student(name = "Bob", surname = "", parentMobile = "", className = "", rate = 15.0))
-        val gId = db.groupDao().insertGroup(StudentGroup(name = "Group A"))
-        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1))
-        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2))
+        val userId = 1L
+        val s1 = db.studentDao().insert(
+            Student(ownerId = userId, name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0)
+        )
+        val s2 = db.studentDao().insert(
+            Student(ownerId = userId, name = "Bob", surname = "", parentMobile = "", className = "", rate = 15.0)
+        )
+        val gId = db.groupDao().insertGroup(StudentGroup(ownerId = userId, name = "Group A"))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1, ownerId = userId))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2, ownerId = userId))
 
-        val lesson = Lesson(studentId = 0, date = "2024-01-05", startTime = "10:00", durationMinutes = 60)
+        val lesson = Lesson(ownerId = userId, studentId = 0, date = "2024-01-05", startTime = "10:00", durationMinutes = 60)
         val useCase = AddGroupLesson(repository)
-        useCase(gId, lesson)
+        useCase(gId, lesson, userId)
 
-        val l1 = db.lessonDao().getLessonsByStudentId(s1).first()
-        val l2 = db.lessonDao().getLessonsByStudentId(s2).first()
+        val l1 = db.lessonDao().getLessonsByStudentId(s1, userId).first()
+        val l2 = db.lessonDao().getLessonsByStudentId(s2, userId).first()
         assertEquals(1, l1.size)
         assertEquals(1, l2.size)
         assertEquals(10.0, l1.first().durationMinutes / 60.0 * 10.0, 0.0)
@@ -60,20 +65,21 @@ class AddGroupLessonIntegrationTest {
 
     @Test
     fun returnsIdsForInsertedLessons() = runBlocking {
-        val s1 = db.studentDao().insert(Student(name = "Ann", surname = "", parentMobile = "", className = "", rate = 12.0))
-        val s2 = db.studentDao().insert(Student(name = "Ben", surname = "", parentMobile = "", className = "", rate = 18.0))
-        val s3 = db.studentDao().insert(Student(name = "Cat", surname = "", parentMobile = "", className = "", rate = 20.0))
-        val gId = db.groupDao().insertGroup(StudentGroup(name = "Group B"))
-        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1))
-        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2))
-        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s3))
+        val userId = 1L
+        val s1 = db.studentDao().insert(Student(ownerId = userId, name = "Ann", surname = "", parentMobile = "", className = "", rate = 12.0))
+        val s2 = db.studentDao().insert(Student(ownerId = userId, name = "Ben", surname = "", parentMobile = "", className = "", rate = 18.0))
+        val s3 = db.studentDao().insert(Student(ownerId = userId, name = "Cat", surname = "", parentMobile = "", className = "", rate = 20.0))
+        val gId = db.groupDao().insertGroup(StudentGroup(ownerId = userId, name = "Group B"))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1, ownerId = userId))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2, ownerId = userId))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s3, ownerId = userId))
 
-        val lesson = Lesson(studentId = 0, date = "2024-02-01", startTime = "09:00", durationMinutes = 90)
+        val lesson = Lesson(ownerId = userId, studentId = 0, date = "2024-02-01", startTime = "09:00", durationMinutes = 90)
         val useCase = AddGroupLesson(repository)
-        val ids = useCase(gId, lesson)
+        val ids = useCase(gId, lesson, userId)
 
         assertEquals(3, ids.size)
-        val lessons = db.lessonDao().getAllLessons().first()
+        val lessons = db.lessonDao().getAllLessons(userId).first()
         assertEquals(3, lessons.size)
     }
 }

--- a/domain/src/test/java/gr/eduinvoice/domain/lesson/AddLessonIntegrationTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/lesson/AddLessonIntegrationTest.kt
@@ -46,7 +46,7 @@ class AddLessonIntegrationTest {
         val lesson = Lesson(studentId = studentId, date = "2024-01-03", startTime = "10:00", durationMinutes = 60)
         val useCase = AddLesson(repository)
         useCase(lesson)
-        val lessons = db.lessonDao().getLessonsByStudentId(studentId).first()
+        val lessons = db.lessonDao().getLessonsByStudentId(studentId, 0).first()
         assertEquals(1, lessons.size)
     }
 }

--- a/domain/src/test/java/gr/eduinvoice/domain/lesson/GetStudentLessonsTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/lesson/GetStudentLessonsTest.kt
@@ -42,10 +42,15 @@ class GetStudentLessonsTest {
 
     @Test
     fun returnsLessonsForStudent() = runBlocking {
-        val studentId = db.studentDao().insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
-        db.lessonDao().insert(Lesson(studentId = studentId, date = "2024-01-01", startTime = "10:00", durationMinutes = 60))
+        val userId = 1L
+        val studentId = db.studentDao().insert(
+            Student(ownerId = userId, name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0)
+        )
+        db.lessonDao().insert(
+            Lesson(ownerId = userId, studentId = studentId, date = "2024-01-01", startTime = "10:00", durationMinutes = 60)
+        )
         val useCase = GetStudentLessons(repository)
-        val lessons = useCase(studentId).first()
+        val lessons = useCase(studentId, userId).first()
         assertEquals(1, lessons.size)
     }
 }

--- a/domain/src/test/java/gr/eduinvoice/domain/lesson/UpdateLessonTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/lesson/UpdateLessonTest.kt
@@ -46,7 +46,7 @@ class UpdateLessonTest {
         val id = db.lessonDao().insert(Lesson(studentId = studentId, date = "2024-01-04", startTime = "10:00", durationMinutes = 60))
         val useCase = UpdateLesson(repository)
         useCase(Lesson(id = id, studentId = studentId, date = "2024-01-04", startTime = "10:00", durationMinutes = 90))
-        val lesson = db.lessonDao().getLessonById(id).first()
+        val lesson = db.lessonDao().getLessonById(id, 0).first()
         assertEquals(90, lesson?.durationMinutes)
     }
 }


### PR DESCRIPTION
## Summary
- add explicit `userId` to lesson use cases and repository methods
- enforce userId on `LessonDao` queries
- update integration tests for new parameter
- bump app version

## Testing
- `./gradlew lintDebug`
- `./gradlew test` *(fails: SocketException)*
- `./gradlew assemble` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6884dfeba010833085e78b399319e12a