### PR TITLE
feat(auth): add password reset flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.22] - 2025-08-22
+### Security
+- Added password reset feature with full-name verification.
+### UI/Design
+- Login screen now links to password reset instead of registration.
+
 ## [0.21.21] - 2025-08-21
 ### Domain
 - Lesson use cases now take `userId` when fetching or adding lessons.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 18
-        versionName "0.21.21"
+        versionCode 19
+        versionName "0.21.22"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
+++ b/app/src/main/java/gr/eduinvoice/NavigationRoutes.kt
@@ -5,6 +5,7 @@ sealed class Screen(val route: String) {
     object Home : Screen("home")
     object Login : Screen("login")
     object Register : Screen("register")
+    object ResetPassword : Screen("resetPassword")
     object Students : Screen("students")
     object Student : Screen("student/{studentId}") {
         fun createRoute(studentId: Long) = "student/$studentId"

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -31,6 +31,7 @@ import gr.eduinvoice.navigation.studentGraph
 import gr.eduinvoice.ui.user.LoginScreen
 import gr.eduinvoice.ui.user.RegisterScreen
 import gr.eduinvoice.ui.user.SessionViewModel
+import gr.eduinvoice.ui.user.ResetPasswordScreen
 
 @Composable
 fun TutorBillingApp() {
@@ -61,7 +62,15 @@ fun TutorBillingApp() {
                         popUpTo(Screen.Welcome.route) { inclusive = true }
                     }
                 },
-                onRegister = { navController.navigate(Screen.Register.route) },
+                onResetPassword = { navController.navigate(Screen.ResetPassword.route) },
+                onSettings = { navController.navigate(Screen.Settings.route) }
+            )
+        }
+
+        composable(Screen.ResetPassword.route) {
+            ResetPasswordScreen(
+                onBack = { navController.popBackStack() },
+                onDone = { navController.popBackStack() },
                 onSettings = { navController.navigate(Screen.Settings.route) }
             )
         }

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -30,7 +30,7 @@ import gr.eduinvoice.R
 fun LoginScreen(
     onBack: () -> Unit,
     onLoggedIn: () -> Unit,
-    onRegister: () -> Unit,
+    onResetPassword: () -> Unit,
     onSettings: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel()
 ) {
@@ -94,8 +94,8 @@ fun LoginScreen(
             Button(onClick = { viewModel.login { onLoggedIn() } }, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.login))
             }
-            TextButton(onClick = onRegister, modifier = Modifier.align(Alignment.End)) {
-                Text(stringResource(R.string.register))
+            TextButton(onClick = onResetPassword, modifier = Modifier.align(Alignment.End)) {
+                Text(stringResource(R.string.forgot_password))
             }
             uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
         }

--- a/app/src/main/java/gr/eduinvoice/ui/user/ResetPasswordScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/ResetPasswordScreen.kt
@@ -1,0 +1,111 @@
+package gr.eduinvoice.ui.user
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gr.eduinvoice.R
+import gr.eduinvoice.ui.design.AppTopBar
+import gr.eduinvoice.ui.design.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ResetPasswordScreen(
+    onBack: () -> Unit,
+    onDone: () -> Unit,
+    onSettings: () -> Unit,
+    viewModel: ResetPasswordViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            AppTopBar(
+                title = stringResource(R.string.reset_password),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSettings) {
+                        Icon(Icons.Default.Settings, contentDescription = stringResource(R.string.settings))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        AnimatedVisibility(
+            visible = true,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .imePadding()
+                    .padding(Dimensions.PaddingMedium),
+                verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
+            ) {
+                Spacer(modifier = Modifier.height(Dimensions.PaddingMedium * 2))
+                Image(
+                    painter = painterResource(R.drawable.tutorbilling_logo),
+                    contentDescription = stringResource(R.string.app_logo_desc),
+                    modifier = Modifier
+                        .size(200.dp)
+                        .align(Alignment.CenterHorizontally)
+                )
+                OutlinedTextField(
+                    value = uiState.username,
+                    onValueChange = viewModel::updateUsername,
+                    label = { Text(stringResource(R.string.username)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = uiState.fullName,
+                    onValueChange = viewModel::updateFullName,
+                    label = { Text(stringResource(R.string.full_name)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = uiState.password,
+                    onValueChange = viewModel::updatePassword,
+                    label = { Text(stringResource(R.string.password)) },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = uiState.confirmPassword,
+                    onValueChange = viewModel::updateConfirmPassword,
+                    label = { Text(stringResource(R.string.confirm_password)) },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Button(onClick = { viewModel.resetPassword(onDone) }, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.reset_password))
+                }
+                uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/gr/eduinvoice/ui/user/ResetPasswordViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/ResetPasswordViewModel.kt
@@ -1,0 +1,51 @@
+package gr.eduinvoice.ui.user
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.eduinvoice.domain.user.UserUseCases
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ResetPasswordViewModel @Inject constructor(
+    private val useCases: UserUseCases
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ResetPasswordUiState())
+    val uiState: StateFlow<ResetPasswordUiState> = _uiState.asStateFlow()
+
+    fun updateUsername(value: String) { _uiState.value = _uiState.value.copy(username = value) }
+    fun updateFullName(value: String) { _uiState.value = _uiState.value.copy(fullName = value) }
+    fun updatePassword(value: String) { _uiState.value = _uiState.value.copy(password = value) }
+    fun updateConfirmPassword(value: String) { _uiState.value = _uiState.value.copy(confirmPassword = value) }
+
+    fun resetPassword(onDone: () -> Unit) {
+        val state = _uiState.value
+        if (state.password != state.confirmPassword) {
+            _uiState.value = state.copy(error = "Passwords do not match")
+            return
+        }
+        viewModelScope.launch {
+            val success = useCases.resetPassword(state.username, state.fullName, state.password)
+            if (success) {
+                onDone()
+            } else {
+                _uiState.value = state.copy(error = "Invalid details")
+            }
+        }
+    }
+
+    fun dismissError() { _uiState.value = _uiState.value.copy(error = null) }
+}
+
+data class ResetPasswordUiState(
+    val username: String = "",
+    val fullName: String = "",
+    val password: String = "",
+    val confirmPassword: String = "",
+    val error: String? = null
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,9 @@
     <string name="password">Password</string>
     <string name="login">Login</string>
     <string name="register">Register</string>
+    <string name="forgot_password">Forgotten your password?</string>
+    <string name="reset_password">Reset Password</string>
+    <string name="confirm_password">Confirm Password</string>
     <string name="full_name">Full Name</string>
     <string name="settings">Settings</string>
 

--- a/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
@@ -25,4 +25,16 @@ class UserRepository @Inject constructor(
         val hash = PasswordHasher.hash(password)
         return if (user.passwordHash == hash) user else null
     }
+
+    suspend fun resetPassword(
+        username: String,
+        fullName: String,
+        newPassword: String
+    ): Boolean {
+        val user = dao.getByUsername(username) ?: return false
+        if (user.fullName != fullName) return false
+        val updated = user.copy(passwordHash = PasswordHasher.hash(newPassword))
+        dao.update(updated)
+        return true
+    }
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/di/DomainModule.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/di/DomainModule.kt
@@ -54,7 +54,8 @@ object DomainModule {
             createUser = CreateUser(repository),
             authenticateUser = AuthenticateUser(repository),
             getUserProfile = GetUserProfile(repository),
-            updateUser = UpdateUser(repository)
+            updateUser = UpdateUser(repository),
+            resetPassword = ResetPassword(repository)
         )
 
     @Provides

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/ResetPassword.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/ResetPassword.kt
@@ -1,0 +1,11 @@
+package gr.eduinvoice.domain.user
+
+import gr.eduinvoice.data.repository.UserRepository
+import javax.inject.Inject
+
+class ResetPassword @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(username: String, fullName: String, newPassword: String): Boolean =
+        repository.resetPassword(username, fullName, newPassword)
+}

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/user/UserUseCases.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/user/UserUseCases.kt
@@ -6,5 +6,6 @@ data class UserUseCases @Inject constructor(
     val createUser: CreateUser,
     val authenticateUser: AuthenticateUser,
     val getUserProfile: GetUserProfile,
-    val updateUser: UpdateUser
+    val updateUser: UpdateUser,
+    val resetPassword: ResetPassword
 )

--- a/domain/src/test/java/gr/eduinvoice/domain/user/ResetPasswordTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/user/ResetPasswordTest.kt
@@ -1,0 +1,70 @@
+package gr.eduinvoice.domain.user
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ResetPasswordTest {
+    private lateinit var db: EduInvoiceDatabase
+    private lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, EduInvoiceDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        repository = UserRepository(db.userDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun resetPasswordWithCorrectDetails() = runBlocking {
+        repository.createUser(
+            User(
+                username = "bob",
+                passwordHash = "old",
+                fullName = "Bob",
+                subjectSpecialty = "Math",
+                yearsExperience = 1
+            )
+        )
+        val useCase = ResetPassword(repository)
+        val result = useCase("bob", "Bob", "new")
+        assertTrue(result)
+        val auth = repository.authenticate("bob", "new")
+        assertTrue(auth != null)
+    }
+
+    @Test
+    fun resetPasswordWithWrongFullName() = runBlocking {
+        repository.createUser(
+            User(
+                username = "bob",
+                passwordHash = "old",
+                fullName = "Bob",
+                subjectSpecialty = "Math",
+                yearsExperience = 1
+            )
+        )
+        val useCase = ResetPassword(repository)
+        val result = useCase("bob", "Alice", "new")
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
- implement `ResetPassword` use case and repository method
- add reset password view model and screen
- replace register link in login screen with password reset
- wire new screen in navigation
- update strings, version and changelog

`./gradlew clean assemble test lintDebug` *(failed: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6884d710f3ac833082980de013f45698