### PR TITLE
feat(auth): provide CurrentUserProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.22] - 2025-08-22
+### App
+- ViewModels fetch logged-in user via `CurrentUserProvider` and pass IDs to use cases.
+
 ## [0.21.21] - 2025-08-21
 ### Domain
 - Lesson use cases now take `userId` when fetching or adding lessons.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 18
-        versionName "0.21.21"
+        versionName "0.21.22"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupScreen.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.*
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
-import gr.eduinvoice.ui.user.SessionViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,8 +21,6 @@ fun GroupScreen(
     viewModel: GroupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val sessionViewModel: SessionViewModel = hiltViewModel()
-    val userId by sessionViewModel.currentUserId.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -35,7 +32,7 @@ fun GroupScreen(
                     }
                 },
                 actions = {
-                    TextButton(onClick = { viewModel.saveGroup(userId ?: 0L); onBack() }) {
+                    TextButton(onClick = { viewModel.saveGroup(); onBack() }) {
                         Text("Save")
                     }
                 }

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
@@ -8,10 +8,8 @@ import gr.eduinvoice.data.model.StudentGroup
 import gr.eduinvoice.domain.group.GroupUseCases
 import gr.eduinvoice.domain.student.StudentUseCases
 import gr.eduinvoice.data.model.Student
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import gr.eduinvoice.data.user.CurrentUserProvider
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,7 +17,8 @@ import javax.inject.Inject
 class GroupViewModel @Inject constructor(
     private val groupUseCases: GroupUseCases,
     private val studentUseCases: StudentUseCases,
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
     val groupId: Long = savedStateHandle.get<Long>("groupId") ?: 0L
 
@@ -30,13 +29,14 @@ class GroupViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val students = studentUseCases.getActiveStudents().first()
+            val userId = currentUserProvider.loggedInUserId.first() ?: 0L
+            val students = studentUseCases.getActiveStudents(userId).first()
             val selectedIds = if (groupId != 0L) {
-                groupUseCases.getGroupStudents(groupId).first().map { it.id }.toSet()
+                groupUseCases.getGroupStudents(groupId, userId).first().map { it.id }.toSet()
             } else emptySet()
             originalStudents = selectedIds
             val selections = students.map { StudentSelection(it.id, it.name, it.surname, it.id in selectedIds) }
-            val name = if (groupId != 0L) groupUseCases.getGroupById(groupId).first()?.name ?: "" else ""
+            val name = if (groupId != 0L) groupUseCases.getGroupById(groupId, userId).first()?.name ?: "" else ""
             _uiState.value = GroupUiState(name = name, students = selections)
         }
     }
@@ -53,8 +53,9 @@ class GroupViewModel @Inject constructor(
         )
     }
 
-    fun saveGroup(userId: Long) {
+    fun saveGroup() {
         viewModelScope.launch {
+            val userId = currentUserProvider.loggedInUserId.first() ?: 0L
             val state = _uiState.value
             val group = StudentGroup(id = groupId, name = state.name)
             val id = if (groupId == 0L) groupUseCases.insertGroup(group) else {

--- a/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsViewModel.kt
@@ -6,17 +6,15 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.database.LessonWithStudent
 import gr.eduinvoice.domain.lesson.LessonUseCases
 import gr.eduinvoice.utils.getFullName
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import gr.eduinvoice.data.user.CurrentUserProvider
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LessonsViewModel @Inject constructor(
-    private val lessonUseCases: LessonUseCases
+    private val lessonUseCases: LessonUseCases,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LessonsUiState())
@@ -24,7 +22,9 @@ class LessonsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            lessonUseCases.getLessonsWithStudents().collect { list ->
+            currentUserProvider.loggedInUserId.filterNotNull().flatMapLatest { uid ->
+                lessonUseCases.getLessonsWithStudents(uid)
+            }.collect { list ->
                 val sorted = list.sortedBy { it.student.getFullName() }
                 _uiState.update { it.copy(lessons = sorted) }
             }
@@ -33,7 +33,8 @@ class LessonsViewModel @Inject constructor(
 
     fun updatePaid(lessonId: Long, paid: Boolean) {
         viewModelScope.launch {
-            val invoiced = lessonUseCases.isLessonInvoiced(lessonId).first() ?: false
+            val userId = currentUserProvider.loggedInUserId.first() ?: 0L
+            val invoiced = lessonUseCases.isLessonInvoiced(lessonId, userId).first() ?: false
             val lesson = _uiState.value.lessons.find { it.lesson.id == lessonId }
             if (invoiced) {
                 _uiState.update { it.copy(dialog = LessonDialog.AlreadyInvoiced(lessonId, paid)) }

--- a/app/src/main/java/gr/eduinvoice/ui/students/StudentsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/students/StudentsViewModel.kt
@@ -9,6 +9,7 @@ import gr.eduinvoice.data.model.StudentWithEarnings
 import gr.eduinvoice.domain.student.StudentUseCases
 import gr.eduinvoice.domain.lesson.LessonUseCases
 import gr.eduinvoice.utils.EarningsCalculator
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -16,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class StudentsViewModel @Inject constructor(
     private val studentUseCases: StudentUseCases,
-    private val lessonUseCases: LessonUseCases
+    private val lessonUseCases: LessonUseCases,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(StudentsUiState())
@@ -42,17 +44,18 @@ class StudentsViewModel @Inject constructor(
 
     private fun loadStudentsWithEarnings() {
         viewModelScope.launch {
-            combine(
-                studentUseCases.getActiveStudents(),
-                lessonUseCases.getAllLessons(),
-                searchQuery,
-                sortAscending
-            ) { students, lessons, query, ascending ->
-                var filtered = if (query.isBlank()) students else students.filter {
-                    it.name.contains(query, true)
-                }
-                filtered = if (ascending) filtered.sortedBy { it.name }
-                else filtered.sortedByDescending { it.name }
+            currentUserProvider.loggedInUserId.filterNotNull().flatMapLatest { uid ->
+                combine(
+                    studentUseCases.getActiveStudents(uid),
+                    lessonUseCases.getAllLessons(uid),
+                    searchQuery,
+                    sortAscending
+                ) { students, lessons, query, ascending ->
+                    var filtered = if (query.isBlank()) students else students.filter {
+                        it.name.contains(query, true)
+                    }
+                    filtered = if (ascending) filtered.sortedBy { it.name }
+                    else filtered.sortedByDescending { it.name }
 
                 filtered.map { student ->
                     val (weekEarnings, monthEarnings) = EarningsCalculator.calculate(student, lessons)
@@ -61,6 +64,7 @@ class StudentsViewModel @Inject constructor(
                         weekEarnings = weekEarnings,
                         monthEarnings = monthEarnings
                     )
+                }
                 }
             }.collect { studentsWithEarnings ->
                 _uiState.update {

--- a/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
@@ -11,6 +11,7 @@ import gr.eduinvoice.data.repository.GroupRepository
 import gr.eduinvoice.data.repository.StudentRepository
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.student.*
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +35,8 @@ class GroupViewModelTest {
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val groupFlow = MutableStateFlow<List<StudentGroup>>(emptyList())
     private val relations = mutableMapOf<Long, MutableMap<Long, Long>>()
+
+    private val userProvider = FakeUserProvider(5L)
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val groupDao = FakeGroupDao(groupFlow, studentFlow, relations)
@@ -68,7 +71,7 @@ class GroupViewModelTest {
         val s2 = Student(id = 2, name = "Bob", surname = "", parentMobile = "", className = "", rate = 15.0)
         studentFlow.value = listOf(s1, s2)
 
-        val vm = GroupViewModel(groupUseCases, studentUseCases, SavedStateHandle())
+        val vm = GroupViewModel(groupUseCases, studentUseCases, SavedStateHandle(), userProvider)
         advanceUntilIdle()
 
         vm.toggleStudent(1)
@@ -85,13 +88,13 @@ class GroupViewModelTest {
         val s2 = Student(id = 2, name = "Bob", surname = "", parentMobile = "", className = "", rate = 15.0)
         studentFlow.value = listOf(s1, s2)
 
-        val vm = GroupViewModel(groupUseCases, studentUseCases, SavedStateHandle())
+        val vm = GroupViewModel(groupUseCases, studentUseCases, SavedStateHandle(), userProvider)
         advanceUntilIdle()
 
         vm.updateName("Group A")
         vm.toggleStudent(1)
         vm.toggleStudent(2)
-        vm.saveGroup(5)
+        vm.saveGroup()
         advanceUntilIdle()
 
         assertEquals(1, groupFlow.value.size)
@@ -106,17 +109,19 @@ class GroupViewModelTest {
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
         override suspend fun softDeleteStudent(studentId: Long) {}
-        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
-        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
+        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
+            flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
+        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> =
+            flow.map { list -> list.filter { it.ownerId == userId } }
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
         override suspend fun restoreStudent(studentId: Long) {}
         override fun getStudentByIdAny(studentId: Long, userId: Long): Flow<Student?> = getStudentById(studentId, userId)
-        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.size
+        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.count { it.ownerId == userId }
         override suspend fun classNameExists(name: String, userId: Long): Int = flow.value.count { it.className.equals(name, true) }
     }
 
     class FakeGroupDao(
-        private val groups: MutableStateFlow<List<StudentGroup>>, 
+        private val groups: MutableStateFlow<List<StudentGroup>>,
         private val students: MutableStateFlow<List<Student>>,
         private val refs: MutableMap<Long, MutableMap<Long, Long>>
     ) : GroupDao {
@@ -132,8 +137,10 @@ class GroupViewModelTest {
             groups.value = groups.value.filterNot { it.id == group.id }
             refs.remove(group.id)
         }
-        override fun getAllGroups(userId: Long): Flow<List<StudentGroup>> = groups.asStateFlow()
-        override fun getGroupById(id: Long, userId: Long): Flow<StudentGroup?> = groups.map { list -> list.find { it.id == id } }
+        override fun getAllGroups(userId: Long): Flow<List<StudentGroup>> =
+            groups.map { list -> list.filter { it.ownerId == userId } }
+        override fun getGroupById(id: Long, userId: Long): Flow<StudentGroup?> =
+            groups.map { list -> list.find { it.id == id && it.ownerId == userId } }
         override suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) {
             refs.getOrPut(crossRef.groupId) { mutableMapOf() }[crossRef.studentId] = crossRef.ownerId
         }
@@ -144,5 +151,10 @@ class GroupViewModelTest {
             val ids = refs[groupId]?.filter { it.value == userId }?.keys ?: emptySet()
             list.filter { it.id in ids }
         }
+    }
+
+    class FakeUserProvider(id: Long?) : CurrentUserProvider {
+        private val _id = MutableStateFlow(id)
+        override val loggedInUserId: Flow<Long?> = _id
     }
 }

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -16,6 +16,7 @@ import gr.eduinvoice.data.model.StudentGroup
 import gr.eduinvoice.data.model.GroupStudentCrossRef
 import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.domain.lesson.*
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,6 +44,7 @@ class LessonsScreenTest {
     private val lessonFlow = MutableStateFlow<List<LessonWithStudent>>(emptyList())
     private val lessonDao = FakeLessonDao(lessonFlow)
     private val groupDao = FakeGroupDao()
+    private val userProvider = FakeUserProvider(1L)
     private val lessonUseCases = LessonUseCases(
         getAllLessons = GetAllLessons(lessonDao),
         getLessonById = GetLessonById(lessonDao),
@@ -89,7 +91,7 @@ class LessonsScreenTest {
                 s2
             )
         )
-        val vm = LessonsViewModel(lessonUseCases)
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
         composeRule.setContent {
             LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
@@ -118,7 +120,7 @@ class LessonsScreenTest {
                 s1
             )
         )
-        val vm = LessonsViewModel(lessonUseCases)
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
         var clicked = false
         composeRule.setContent {
             LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
@@ -151,9 +153,12 @@ class FakeLessonDao(private val flow: MutableStateFlow<List<LessonWithStudent>>)
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
         override suspend fun deleteById(lessonId: Long) {}
-        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { it.find { l -> l.lesson.id == lessonId }?.lesson }
-        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.lesson.studentId == studentId }.map { it.lesson } }
-        override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.map { list -> list.map { it.lesson } }
+        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =
+            flow.map { it.find { l -> l.lesson.id == lessonId && l.lesson.ownerId == userId }?.lesson }
+        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.lesson.studentId == studentId && it.lesson.ownerId == userId }.map { it.lesson } }
+        override fun getAllLessons(userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.lesson.ownerId == userId }.map { it.lesson } }
         override fun getLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
@@ -164,11 +169,12 @@ class FakeLessonDao(private val flow: MutableStateFlow<List<LessonWithStudent>>)
         override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
             flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isInvoiced = invoiced)) else it }
         }
-        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> = flow.map { list ->
-            list.find { it.lesson.id == lessonId }?.lesson?.isInvoiced
-        }
-        override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> = flow.asStateFlow()
-        override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flow.map { list -> list.filter { it.student.id == studentId } }
+        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> =
+            flow.map { list -> list.find { it.lesson.id == lessonId && it.lesson.ownerId == userId }?.lesson?.isInvoiced }
+        override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> =
+            flow.map { list -> list.filter { it.lesson.ownerId == userId } }
+        override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> =
+            flow.map { list -> list.filter { it.student.id == studentId && it.lesson.ownerId == userId } }
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
     }
@@ -182,5 +188,10 @@ class FakeLessonDao(private val flow: MutableStateFlow<List<LessonWithStudent>>)
         override suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) {}
         override suspend fun deleteCrossRef(groupId: Long, studentId: Long, userId: Long) {}
         override fun getStudentsForGroup(groupId: Long, userId: Long): Flow<List<Student>> = flowOf(emptyList())
+    }
+
+    class FakeUserProvider(id: Long?) : CurrentUserProvider {
+        private val _id = MutableStateFlow(id)
+        override val loggedInUserId: Flow<Long?> = _id
     }
 }

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -11,6 +11,7 @@ import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.model.StudentGroup
 import gr.eduinvoice.data.model.GroupStudentCrossRef
 import gr.eduinvoice.domain.lesson.*
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +35,8 @@ class LessonsViewModelTest {
 
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val lessonFlow = MutableStateFlow<List<LessonWithStudent>>(emptyList())
+
+    private val userProvider = FakeUserProvider(1L)
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val lessonDao = FakeLessonDao(lessonFlow)
@@ -87,7 +90,7 @@ class LessonsViewModelTest {
             )
         )
 
-        val vm = LessonsViewModel(lessonUseCases)
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
         advanceUntilIdle()
 
         val list = vm.uiState.value.lessons
@@ -115,7 +118,7 @@ class LessonsViewModelTest {
             )
         )
 
-        val vm = LessonsViewModel(lessonUseCases)
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
         advanceUntilIdle()
 
         vm.updatePaid(1, true)
@@ -143,7 +146,7 @@ class LessonsViewModelTest {
             )
         )
 
-        val vm = LessonsViewModel(lessonUseCases)
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
         advanceUntilIdle()
 
         vm.updatePaid(1, true)
@@ -160,12 +163,15 @@ class LessonsViewModelTest {
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
         override suspend fun softDeleteStudent(studentId: Long) {}
-        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
-        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
+        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
+            flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
+        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> =
+            flow.map { list -> list.filter { it.ownerId == userId } }
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
         override suspend fun restoreStudent(studentId: Long) {}
-        override fun getStudentByIdAny(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
-        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.size
+        override fun getStudentByIdAny(studentId: Long, userId: Long): Flow<Student?> =
+            flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
+        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.count { it.ownerId == userId }
         override suspend fun classNameExists(name: String, userId: Long): Int = flow.value.count { it.className.equals(name, true) }
     }
 
@@ -174,9 +180,12 @@ class LessonsViewModelTest {
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
         override suspend fun deleteById(lessonId: Long) {}
-        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { it.find { l -> l.lesson.id == lessonId }?.lesson }
-        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.lesson.studentId == studentId }.map { it.lesson } }
-        override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.map { list -> list.map { it.lesson } }
+        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =
+            flow.map { it.find { l -> l.lesson.id == lessonId && l.lesson.ownerId == userId }?.lesson }
+        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.lesson.studentId == studentId && it.lesson.ownerId == userId }.map { it.lesson } }
+        override fun getAllLessons(userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.lesson.ownerId == userId }.map { it.lesson } }
         override fun getLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
@@ -187,11 +196,12 @@ class LessonsViewModelTest {
         override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {
             flow.value = flow.value.map { if (it.lesson.id in ids) it.copy(lesson = it.lesson.copy(isInvoiced = invoiced)) else it }
         }
-        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> = flow.map { list ->
-            list.find { it.lesson.id == lessonId }?.lesson?.isInvoiced
-        }
-        override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> = flow.asStateFlow()
-        override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flow.map { list -> list.filter { it.student.id == studentId } }
+        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> =
+            flow.map { list -> list.find { it.lesson.id == lessonId && it.lesson.ownerId == userId }?.lesson?.isInvoiced }
+        override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> =
+            flow.map { list -> list.filter { it.lesson.ownerId == userId } }
+        override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> =
+            flow.map { list -> list.filter { it.student.id == studentId && it.lesson.ownerId == userId } }
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
     }
@@ -205,5 +215,10 @@ class LessonsViewModelTest {
         override suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) {}
         override suspend fun deleteCrossRef(groupId: Long, studentId: Long, userId: Long) {}
         override fun getStudentsForGroup(groupId: Long, userId: Long): Flow<List<Student>> = flowOf(emptyList())
+    }
+
+    class FakeUserProvider(id: Long?) : CurrentUserProvider {
+        private val _id = MutableStateFlow(id)
+        override val loggedInUserId: Flow<Long?> = _id
     }
 }

--- a/data/src/main/java/gr/eduinvoice/data/di/UserPreferencesModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/UserPreferencesModule.kt
@@ -1,0 +1,17 @@
+package gr.eduinvoice.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import gr.eduinvoice.data.user.CurrentUserProvider
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserPreferencesModule {
+    @Binds
+    @Singleton
+    abstract fun bindCurrentUserProvider(repo: UserPreferencesRepository): CurrentUserProvider
+}

--- a/data/src/main/java/gr/eduinvoice/data/user/CurrentUserProvider.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/CurrentUserProvider.kt
@@ -1,0 +1,7 @@
+package gr.eduinvoice.data.user
+
+import kotlinx.coroutines.flow.Flow
+
+interface CurrentUserProvider {
+    val loggedInUserId: Flow<Long?>
+}

--- a/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
@@ -17,13 +17,13 @@ private val Context.userPrefsDataStore by preferencesDataStore(name = "user_pref
 @Singleton
 class UserPreferencesRepository @Inject constructor(
     @ApplicationContext private val context: Context
-) {
+) : CurrentUserProvider {
     private object Keys {
         val LOGGED_IN_USER = longPreferencesKey("logged_in_user")
         val DB_PASSPHRASE = stringPreferencesKey("db_passphrase")
     }
 
-    val loggedInUserId: Flow<Long?> = context.userPrefsDataStore.data.map { prefs ->
+    override val loggedInUserId: Flow<Long?> = context.userPrefsDataStore.data.map { prefs ->
         prefs[Keys.LOGGED_IN_USER]
     }
 


### PR DESCRIPTION
- inject lightweight `CurrentUserProvider` implemented by `UserPreferencesRepository`
- use provider in student, lesson and group view models
- update screens and unit tests to pass user IDs

`./gradlew test` fails due to network restrictions


------
https://chatgpt.com/codex/tasks/task_e_6884e78f55008330aba30145ca446581