### PR TITLE
feat(security): migrate to BCrypt hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.23] - 2025-08-23
+### Security
+- Passwords now hashed with BCrypt and upgraded on login.
+
 ## [0.21.22] - 2025-08-22
 ### App
 - ViewModels fetch logged-in user via `CurrentUserProvider` and pass IDs to use cases.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.22"
+        versionName "0.21.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     implementation "androidx.datastore:datastore-preferences:1.1.7"
 
+    implementation "org.mindrot:jbcrypt:0.4"
+
     implementation "com.google.dagger:hilt-android:2.54"
     ksp "com.google.dagger:hilt-compiler:2.54"
 

--- a/data/src/main/java/gr/eduinvoice/data/repository/PasswordHasher.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/PasswordHasher.kt
@@ -1,11 +1,26 @@
 package gr.eduinvoice.data.repository
 
 import java.security.MessageDigest
+import org.mindrot.jbcrypt.BCrypt
 
 object PasswordHasher {
-    fun hash(password: String): String {
+    private fun sha256(password: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val bytes = digest.digest(password.toByteArray())
         return bytes.joinToString("") { "%02x".format(it) }
     }
+
+    fun hash(password: String): String = BCrypt.hashpw(password, BCrypt.gensalt())
+
+    fun verify(password: String, storedHash: String): Boolean {
+        return if (storedHash.startsWith("$2")) {
+            BCrypt.checkpw(password, storedHash)
+        } else {
+            sha256(password) == storedHash
+        }
+    }
+
+    fun needsMigration(storedHash: String): Boolean = !storedHash.startsWith("$2")
+
+    fun legacyHash(password: String): String = sha256(password)
 }

--- a/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/UserRepository.kt
@@ -22,8 +22,14 @@ class UserRepository @Inject constructor(
 
     suspend fun authenticate(username: String, password: String): User? {
         val user = dao.getByUsername(username) ?: return null
-        val hash = PasswordHasher.hash(password)
-        return if (user.passwordHash == hash) user else null
+        val valid = PasswordHasher.verify(password, user.passwordHash)
+        if (!valid) return null
+        if (PasswordHasher.needsMigration(user.passwordHash)) {
+            val updated = user.copy(passwordHash = PasswordHasher.hash(password))
+            dao.update(updated)
+            return updated
+        }
+        return user
     }
 
     suspend fun resetPassword(

--- a/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/user/AuthenticateUserTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import gr.eduinvoice.data.database.EduInvoiceDatabase
 import gr.eduinvoice.data.repository.UserRepository
+import gr.eduinvoice.data.repository.PasswordHasher
 import gr.eduinvoice.data.model.User
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -64,5 +65,30 @@ class AuthenticateUserTest {
         val useCase = AuthenticateUser(repository)
         val user = useCase("alice", "wrong")
         assertNull(user)
+    }
+
+    @Test
+    fun authenticateMigratesLegacyHash() = runBlocking {
+        val dao = db.userDao()
+        val legacy = PasswordHasher.legacyHash("secret")
+        dao.insert(
+            User(
+                username = "mike",
+                passwordHash = legacy,
+                fullName = "Mike",
+                subjectSpecialty = "Chemistry",
+                yearsExperience = 2
+            )
+        )
+
+        val useCase = AuthenticateUser(repository)
+        val user = useCase("mike", "secret")
+        assertNotNull(user)
+
+        val updated = dao.getByUsername("mike")
+        assertNotNull(updated)
+        if (updated != null) {
+            assert(updated.passwordHash.startsWith("$2"))
+        }
     }
 }


### PR DESCRIPTION
- replace SHA-256 hashing with BCrypt in PasswordHasher
- upgrade UserRepository authentication to migrate old hashes
- add unit test verifying migration
- bump version and changelog

Tested with `./gradlew assemble`, `./gradlew test`, `./gradlew lintDebug` *(failed to run on CI)*

------
https://chatgpt.com/codex/tasks/task_e_6884ffffa3a883309c9bb59a604161ca