### PR TITLE
feat(security): encrypt DB passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.23] - 2025-08-23
+### Security
+- Database passphrase stored encrypted in Android Keystore.
+
 ## [0.21.22] - 2025-08-22
 ### App
 - ViewModels fetch logged-in user via `CurrentUserProvider` and pass IDs to use cases.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.22"
+        versionName "0.21.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "net.zetetic:android-database-sqlcipher:4.5.4"
 
     implementation "androidx.datastore:datastore-preferences:1.1.7"
+    implementation "androidx.security:security-crypto:1.1.0-beta01"
 
     implementation "com.google.dagger:hilt-android:2.54"
     ksp "com.google.dagger:hilt-compiler:2.54"

--- a/data/src/main/java/gr/eduinvoice/data/user/PassphraseCrypto.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/PassphraseCrypto.kt
@@ -1,0 +1,68 @@
+package gr.eduinvoice.data.user
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import kotlin.random.Random
+
+private const val KEY_ALIAS = "db_passphrase_key"
+private const val ENC_PREFIX = "enc:"
+private const val IV_SIZE = 12
+
+internal class PassphraseCrypto(context: Context) {
+    private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+
+    private fun getSecretKey(): SecretKey {
+        val existing = keyStore.getKey(KEY_ALIAS, null) as? SecretKey
+        if (existing != null) return existing
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .build()
+        keyGenerator.init(spec)
+        return keyGenerator.generateKey()
+    }
+
+    fun generatePassphrase(): String {
+        val bytes = ByteArray(32)
+        Random.nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.NO_WRAP)
+    }
+
+    fun encrypt(plain: String): String {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, getSecretKey())
+        val iv = cipher.iv
+        val encrypted = cipher.doFinal(plain.toByteArray(Charsets.UTF_8))
+        val combined = ByteArray(iv.size + encrypted.size)
+        System.arraycopy(iv, 0, combined, 0, iv.size)
+        System.arraycopy(encrypted, 0, combined, iv.size, encrypted.size)
+        return ENC_PREFIX + Base64.encodeToString(combined, Base64.NO_WRAP)
+    }
+
+    fun decrypt(data: String): String {
+        val raw = if (data.startsWith(ENC_PREFIX)) data.substring(ENC_PREFIX.length) else data
+        val bytes = Base64.decode(raw, Base64.NO_WRAP)
+        val iv = bytes.copyOfRange(0, IV_SIZE)
+        val cipherText = bytes.copyOfRange(IV_SIZE, bytes.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val spec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.DECRYPT_MODE, getSecretKey(), spec)
+        val decrypted = cipher.doFinal(cipherText)
+        return String(decrypted, Charsets.UTF_8)
+    }
+
+    fun isEncrypted(data: String?): Boolean = data?.startsWith(ENC_PREFIX) == true
+}
+
+internal const val ENCRYPTED_PREFIX = ENC_PREFIX

--- a/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/UserPreferencesRepository.kt
@@ -5,6 +5,8 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
+import gr.eduinvoice.data.user.ENCRYPTED_PREFIX
+import gr.eduinvoice.data.user.PassphraseCrypto
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -18,6 +20,7 @@ private val Context.userPrefsDataStore by preferencesDataStore(name = "user_pref
 class UserPreferencesRepository @Inject constructor(
     @ApplicationContext private val context: Context
 ) : CurrentUserProvider {
+    private val crypto = PassphraseCrypto(context)
     private object Keys {
         val LOGGED_IN_USER = longPreferencesKey("logged_in_user")
         val DB_PASSPHRASE = stringPreferencesKey("db_passphrase")
@@ -28,12 +31,24 @@ class UserPreferencesRepository @Inject constructor(
     }
 
     suspend fun getDbPassphrase(): String {
-        val prefs = context.userPrefsDataStore.data.first()
-        return prefs[Keys.DB_PASSPHRASE] ?: "eduinvoice"
+        var stored = context.userPrefsDataStore.data.first()[Keys.DB_PASSPHRASE]
+        if (stored == null) {
+            val pass = crypto.generatePassphrase()
+            stored = crypto.encrypt(pass)
+            context.userPrefsDataStore.edit { it[Keys.DB_PASSPHRASE] = stored!! }
+            return pass
+        }
+        if (!crypto.isEncrypted(stored)) {
+            val enc = crypto.encrypt(stored)
+            context.userPrefsDataStore.edit { it[Keys.DB_PASSPHRASE] = enc }
+            stored = enc
+        }
+        return crypto.decrypt(stored)
     }
 
     suspend fun setDbPassphrase(passphrase: String) {
-        context.userPrefsDataStore.edit { it[Keys.DB_PASSPHRASE] = passphrase }
+        val enc = crypto.encrypt(passphrase)
+        context.userPrefsDataStore.edit { it[Keys.DB_PASSPHRASE] = enc }
     }
 
     suspend fun setLoggedInUser(id: Long?) {

--- a/data/src/test/java/gr/eduinvoice/data/user/UserPreferencesRepositoryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/user/UserPreferencesRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,7 +32,7 @@ class UserPreferencesRepositoryTest {
     @Test
     fun databasePassphraseDefault() = runBlocking {
         val default = repo.getDbPassphrase()
-        assertEquals("eduinvoice", default)
+        assertTrue(default.isNotEmpty())
         repo.setDbPassphrase("secret")
         assertEquals("secret", repo.getDbPassphrase())
     }


### PR DESCRIPTION
- WHAT changed
  - Generated random passphrase stored encrypted with Android Keystore
  - Updated `UserPreferencesRepository` to decrypt value when accessed
  - Added `PassphraseCrypto` utility
  - Updated unit tests and version numbers
- WHY it matters
  - Removes plain-text database password from preferences
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688500006d648330a39abaa7c8564838