### PR TITLE
fix(group): remove from group with owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.24] - 2025-08-24
+### App
+- Group deletion now passes `userId` to `removeStudentFromGroup` ensuring only the owner's records are affected.
+
 ## [0.21.23] - 2025-08-23
 ### Security
 - Database passphrase stored encrypted in Android Keystore.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.23"
+        versionName "0.21.24"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupViewModel.kt
@@ -67,7 +67,7 @@ class GroupViewModel @Inject constructor(
             val toAdd = selected - originalStudents
             val toRemove = originalStudents - selected
             toAdd.forEach { groupUseCases.addStudentToGroup(id, it, userId) }
-            toRemove.forEach { groupUseCases.removeStudentFromGroup(id, it) }
+            toRemove.forEach { groupUseCases.removeStudentFromGroup(id, it, userId) }
         }
     }
 }


### PR DESCRIPTION
- WHAT changed
  - pass userId to removeStudentFromGroup in GroupViewModel
  - bump versionName to 0.21.24 and document change
- WHY it matters
  - ensures group student deletions are scoped to the logged-in user
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_68850fa6fbc48330bfe29d3e002d7a16