### PR TITLE
feat(student): fetch user ID in StudentViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.25] - 2025-08-25
+### App
+- StudentViewModel now receives CurrentUserProvider and passes user IDs to domain use cases.
+
 ## [0.21.24] - 2025-08-24
 ### App
 - Group deletion now passes `userId` to `removeStudentFromGroup` ensuring only the owner's records are affected.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.24"
+        versionName "0.21.25"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -19,6 +19,7 @@ import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +37,7 @@ class StudentScreenTest {
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     private lateinit var viewModel: StudentViewModel
+    private val userProvider = FakeUserProvider(1L)
 
     @Before
     fun setup() {
@@ -122,7 +124,7 @@ class StudentScreenTest {
             removeStudentFromGroup = RemoveStudentFromGroup(groupRepo),
             getGroupStudents = GetGroupStudents(groupRepo)
         )
-        viewModel = StudentViewModel(studentUseCases, lessonUseCases, androidx.lifecycle.SavedStateHandle(mapOf("studentId" to 1L)))
+        viewModel = StudentViewModel(studentUseCases, lessonUseCases, androidx.lifecycle.SavedStateHandle(mapOf("studentId" to 1L)), userProvider)
     }
 
     @Test
@@ -139,5 +141,10 @@ class StudentScreenTest {
 
         composeRule.onNodeWithContentDescription("Edit").performClick()
         composeRule.onNodeWithText("Save").assertExists()
+    }
+
+    class FakeUserProvider(id: Long?) : CurrentUserProvider {
+        private val _id = MutableStateFlow(id)
+        override val loggedInUserId: Flow<Long?> = _id
     }
 }

--- a/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
@@ -18,13 +18,15 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.util.Patterns
+import gr.eduinvoice.data.user.CurrentUserProvider
 import javax.inject.Inject
 
 @HiltViewModel
 class StudentViewModel @Inject constructor(
     private val studentUseCases: StudentUseCases,
     private val lessonUseCases: LessonUseCases,
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     val studentId: Long = savedStateHandle.get<Long>("studentId") ?: 0L
@@ -50,9 +52,10 @@ class StudentViewModel @Inject constructor(
 
     private fun loadData() {
         viewModelScope.launch {
+            val userId = currentUserProvider.loggedInUserId.first() ?: 0L
             combine(
-                studentUseCases.getStudentById(studentId),
-                lessonUseCases.getStudentLessons(studentId)
+                studentUseCases.getStudentById(studentId, userId),
+                lessonUseCases.getStudentLessons(studentId, userId)
             ) { student, lessons -> student to lessons }
                 .catch { e ->
                     _uiState.update { it.copy(errorMessage = e.message) }
@@ -158,7 +161,8 @@ class StudentViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true) }
 
             try {
-                if (state.selectedClass == "Custom" && studentUseCases.classNameExists(className)) {
+                val userId = currentUserProvider.loggedInUserId.first() ?: 0L
+                if (state.selectedClass == "Custom" && studentUseCases.classNameExists(className, userId)) {
                     _uiState.update {
                         it.copy(isLoading = false, errorMessage = "Class already exists")
                     }

--- a/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
@@ -15,6 +15,7 @@ import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +38,8 @@ class StudentViewModelTest {
 
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val lessonFlow = MutableStateFlow<List<Lesson>>(emptyList())
+
+    private val userProvider = FakeUserProvider(1L)
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val lessonDao = FakeLessonDao(lessonFlow)
@@ -72,7 +75,7 @@ class StudentViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun saveStudentClearsLoading() = runTest {
-        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 0L)))
+        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 0L)), userProvider)
         vm.updateName("Alice")
         vm.updateSurname("Smith")
         vm.updateSelectedClass("A")
@@ -87,7 +90,7 @@ class StudentViewModelTest {
     fun deleteStudentClearsLoading() = runTest {
         val student = Student(id = 1, name = "Bob", surname = "", parentMobile = "", className = "A", rate = 10.0)
         studentFlow.value = listOf(student)
-        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 1L)))
+        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 1L)), userProvider)
         advanceUntilIdle()
         vm.deleteStudent()
         advanceUntilIdle()
@@ -148,6 +151,11 @@ class StudentViewModelTest {
         override suspend fun insertCrossRef(crossRef: GroupStudentCrossRef) {}
         override suspend fun deleteCrossRef(groupId: Long, studentId: Long, userId: Long) {}
         override fun getStudentsForGroup(groupId: Long, userId: Long): Flow<List<Student>> = flowOf(emptyList())
+    }
+
+    class FakeUserProvider(id: Long?) : CurrentUserProvider {
+        private val _id = MutableStateFlow(id)
+        override val loggedInUserId: Flow<Long?> = _id
     }
 }
 


### PR DESCRIPTION
- inject `CurrentUserProvider` into `StudentViewModel`
- forward logged-in user ID to student and lesson use cases
- update view model tests with a fake user provider
- bump versionName and changelog

------
https://chatgpt.com/codex/tasks/task_e_68850fa726c88330827ecfc6f862da38