### PR TITLE
fix(data): enforce user scoped deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 - Tests verify user data isolation when loading or updating lessons.
 - Group deletion now passes `userId` to `removeStudentFromGroup` ensuring only the owner's records are affected.
 
+## [0.21.25] - 2025-08-25
+### Data
+- `softDeleteStudent` and `deleteById` now filter by `ownerId`.
+- Repositories and tests updated to pass the current user ID.
+
 ## [0.21.23] - 2025-08-23
 ### Security
 - Database passphrase stored encrypted in Android Keystore.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.24"
+        versionName "0.21.25"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
@@ -52,7 +52,7 @@ class InvoiceScreenTest {
             override suspend fun insert(student: Student): Long = 1L
             override suspend fun update(student: Student) {}
             override suspend fun delete(student: Student) {}
-            override suspend fun softDeleteStudent(studentId: Long) {}
+            override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
             override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = studentFlow.map { it.first() }
             override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = studentFlow.asStateFlow()
             override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -45,7 +45,7 @@ class StudentScreenTest {
             override suspend fun insert(student: Student): Long = 1L
             override suspend fun update(student: Student) {}
             override suspend fun delete(student: Student) {}
-            override suspend fun softDeleteStudent(studentId: Long) {}
+            override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
             override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = studentFlow.map { it.first() }
             override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = studentFlow.asStateFlow()
             override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())

--- a/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
@@ -11,6 +11,7 @@ import gr.eduinvoice.data.model.RateTypes
 import gr.eduinvoice.domain.lesson.LessonUseCases
 import gr.eduinvoice.domain.student.StudentUseCases
 import gr.eduinvoice.domain.group.GroupUseCases
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -24,7 +25,8 @@ class LessonViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val lessonUseCases: LessonUseCases,
     private val studentUseCases: StudentUseCases,
-    private val groupUseCases: GroupUseCases
+    private val groupUseCases: GroupUseCases,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
@@ -261,7 +263,8 @@ class LessonViewModel @Inject constructor(
     fun deleteLesson() {
         viewModelScope.launch(Dispatchers.IO) {
             lessonId?.takeIf { it != 0L }?.let { id ->
-                lessonUseCases.deleteLesson(id)
+                val uid = currentUserProvider.loggedInUserId.firstOrNull() ?: 0L
+                lessonUseCases.deleteLesson(id, uid)
 
                 // Navigate back on main thread
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
@@ -220,7 +220,8 @@ class StudentViewModel @Inject constructor(
 
             try {
                 _uiState.value.student?.let { student ->
-                    studentUseCases.softDeleteStudent(student.id)
+                    val uid = currentUserProvider.loggedInUserId.firstOrNull() ?: 0L
+                    studentUseCases.softDeleteStudent(student.id, uid)
 
                     // Clear loading and navigate back on main thread
                     withContext(Dispatchers.Main) {
@@ -241,7 +242,8 @@ class StudentViewModel @Inject constructor(
 
     fun deleteLesson(id: Long) {
         viewModelScope.launch(Dispatchers.IO) {
-            lessonUseCases.deleteLesson(id)
+            val uid = currentUserProvider.loggedInUserId.firstOrNull() ?: 0L
+            lessonUseCases.deleteLesson(id, uid)
         }
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/students/StudentsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/students/StudentsViewModel.kt
@@ -79,7 +79,8 @@ class StudentsViewModel @Inject constructor(
 
     fun deleteStudent(studentId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
-            studentUseCases.softDeleteStudent(studentId)
+            val uid = currentUserProvider.loggedInUserId.firstOrNull() ?: 0L
+            studentUseCases.softDeleteStudent(studentId, uid)
         }
     }
 }

--- a/app/src/test/java/gr/eduinvoice/data/StudentDaoArchiveTest.kt
+++ b/app/src/test/java/gr/eduinvoice/data/StudentDaoArchiveTest.kt
@@ -39,7 +39,7 @@ class StudentDaoArchiveTest {
     @Test
     fun softDeleteAndRestoreStudent() = runBlocking {
         val id = dao.insert(Student(name = "Alice", surname = "", parentMobile = "", className = "", rate = 10.0))
-        dao.softDeleteStudent(id)
+        dao.softDeleteStudent(id, 0)
         val archived = dao.getArchivedStudents(0).first()
         assertEquals(1, archived.size)
         dao.restoreStudent(id)
@@ -51,7 +51,7 @@ class StudentDaoArchiveTest {
     @Test
     fun getStudentByIdAnyReturnsArchived() = runBlocking {
         val id = dao.insert(Student(name = "Bob", surname = "", parentMobile = "", className = "", rate = 12.0))
-        dao.softDeleteStudent(id)
+        dao.softDeleteStudent(id, 0)
         val student = dao.getStudentByIdAny(id, 0).first()
         assertNotNull(student)
         assertEquals(false, student?.isActive)

--- a/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
@@ -108,7 +108,7 @@ class GroupViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
             flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> =

--- a/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
@@ -111,7 +111,7 @@ class HomeMenuViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
@@ -128,7 +128,7 @@ class HomeMenuViewModelTest {
         }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { it.find { l -> l.id == lessonId } }
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.studentId == studentId } }
         override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.asStateFlow()

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
@@ -42,7 +42,7 @@ class InvoiceViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long) = studentFlow.map { list -> list.find { it.id == studentId } }
         override fun getAllActiveStudents(userId: Long) = studentFlow.asStateFlow()
         override fun getArchivedStudents(userId: Long) = flowOf(emptyList<Student>())
@@ -59,7 +59,7 @@ class InvoiceViewModelTest {
         }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long) = lessonFlow.map { it.find { l -> l.id == lessonId } }
         override fun getLessonsByStudentId(studentId: Long, userId: Long) = lessonFlow.map { list -> list.filter { it.studentId == studentId } }
         override fun getAllLessons(userId: Long) = lessonFlow.asStateFlow()

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
@@ -57,7 +57,7 @@ class LessonScreenTest {
         override suspend fun insert(student: Student): Long = 0L
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flowOf(null)
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = studentFlow.asStateFlow()
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
@@ -71,7 +71,7 @@ class LessonScreenTest {
         override suspend fun insert(lesson: Lesson): Long = 0L
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flowOf(null)
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flowOf(emptyList())

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
@@ -159,7 +159,7 @@ class LessonViewModelGroupTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
@@ -177,7 +177,7 @@ class LessonViewModelGroupTest {
         }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { list -> list.find { it.id == lessonId } }
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.studentId == studentId } }
         override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.asStateFlow()

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -138,7 +138,7 @@ class LessonsScreenTest {
         override suspend fun insert(student: Student): Long = 0L
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flowOf(null)
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
@@ -152,7 +152,7 @@ class FakeLessonDao(private val flow: MutableStateFlow<List<LessonWithStudent>>)
         override suspend fun insert(lesson: Lesson): Long = 0L
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =
             flow.map { it.find { l -> l.lesson.id == lessonId && l.lesson.ownerId == userId }?.lesson }
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> =

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -186,7 +186,7 @@ class LessonsViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
             flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> =
@@ -203,7 +203,7 @@ class LessonsViewModelTest {
         override suspend fun insert(lesson: Lesson): Long { return 0L }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =
             flow.map { it.find { l -> l.lesson.id == lessonId && l.lesson.ownerId == userId }?.lesson }
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> =

--- a/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
@@ -125,7 +125,7 @@ class RevenueViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {}
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {}
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
         override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
@@ -142,7 +142,7 @@ class RevenueViewModelTest {
         }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {}
+        override suspend fun deleteById(lessonId: Long, userId: Long) {}
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { it.find { l -> l.id == lessonId } }
         override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.studentId == studentId } }
         override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.asStateFlow()

--- a/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
@@ -118,7 +118,7 @@ class StudentViewModelTest {
         }
         override suspend fun update(student: Student) {}
         override suspend fun delete(student: Student) {}
-        override suspend fun softDeleteStudent(studentId: Long) {
+        override suspend fun softDeleteStudent(studentId: Long, userId: Long) {
             flow.value = flow.value.filterNot { it.id == studentId }
         }
         override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
@@ -139,7 +139,7 @@ class StudentViewModelTest {
         }
         override suspend fun update(lesson: Lesson) {}
         override suspend fun delete(lesson: Lesson) {}
-        override suspend fun deleteById(lessonId: Long) {
+        override suspend fun deleteById(lessonId: Long, userId: Long) {
             flow.value = flow.value.filterNot { it.id == lessonId }
         }
         override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =

--- a/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
+++ b/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
@@ -16,8 +16,8 @@ interface LessonDao {
     @Delete
     suspend fun delete(lesson: Lesson)
 
-    @Query("DELETE FROM lessons WHERE id = :lessonId")
-    suspend fun deleteById(lessonId: Long)
+    @Query("DELETE FROM lessons WHERE id = :lessonId AND ownerId = :userId")
+    suspend fun deleteById(lessonId: Long, userId: Long)
 
     @Query("SELECT * FROM lessons WHERE id = :lessonId AND ownerId = :userId")
     fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?>

--- a/data/src/main/java/gr/eduinvoice/data/dao/StudentDao.kt
+++ b/data/src/main/java/gr/eduinvoice/data/dao/StudentDao.kt
@@ -15,8 +15,8 @@ interface StudentDao {
     @Delete
     suspend fun delete(student: Student)
 
-    @Query("UPDATE students SET isActive = 0 WHERE id = :studentId")
-    suspend fun softDeleteStudent(studentId: Long)
+    @Query("UPDATE students SET isActive = 0 WHERE id = :studentId AND ownerId = :userId")
+    suspend fun softDeleteStudent(studentId: Long, userId: Long)
 
     @Query("SELECT * FROM students WHERE id = :studentId AND ownerId = :userId AND isActive = 1")
     fun getStudentById(studentId: Long, userId: Long): Flow<Student?>

--- a/data/src/main/java/gr/eduinvoice/data/repository/StudentRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/StudentRepository.kt
@@ -13,7 +13,8 @@ class StudentRepository @Inject constructor(
     suspend fun insertStudent(student: Student): Long = studentDao.insert(student)
     suspend fun updateStudent(student: Student) = studentDao.update(student)
     suspend fun deleteStudent(student: Student) = studentDao.delete(student)
-    suspend fun softDeleteStudent(studentId: Long) = studentDao.softDeleteStudent(studentId)
+    suspend fun softDeleteStudent(studentId: Long, userId: Long) =
+        studentDao.softDeleteStudent(studentId, userId)
     fun getStudentById(id: Long, userId: Long): Flow<Student?> = getStudentByIdAny(id, userId)
     fun getStudentByIdAny(id: Long, userId: Long): Flow<Student?> =
         studentDao.getStudentByIdAny(id, userId)

--- a/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
@@ -59,8 +59,8 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Soft deletes a student by setting 'isActive' to false.
      */
-    suspend fun deleteStudent(studentId: Long) {
-        studentDao.softDeleteStudent(studentId)
+    suspend fun deleteStudent(studentId: Long, userId: Long) {
+        studentDao.softDeleteStudent(studentId, userId)
     }
 
     /**
@@ -119,8 +119,8 @@ class TutorBillingRepository @Inject constructor(
     /**
      * Deletes a lesson permanently by its ID.
      */
-    suspend fun deleteLesson(lessonId: Long) {
-        lessonDao.deleteById(lessonId)
+    suspend fun deleteLesson(lessonId: Long, userId: Long) {
+        lessonDao.deleteById(lessonId, userId)
     }
 
     /**

--- a/data/src/test/java/gr/eduinvoice/data/StudentDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/StudentDaoTest.kt
@@ -47,7 +47,7 @@ class StudentDaoTest {
     @Test
     fun softDeleteAndRestoreStudent() = runBlocking {
         val id = dao.insert(Student(name = "Bob", surname = "", parentMobile = "", className = "", rate = 12.0))
-        dao.softDeleteStudent(id)
+        dao.softDeleteStudent(id, 0)
         val archived = dao.getArchivedStudents(0).first()
         assertEquals(1, archived.size)
         dao.restoreStudent(id)
@@ -58,7 +58,7 @@ class StudentDaoTest {
     @Test
     fun getStudentByIdAnyReturnsArchived() = runBlocking {
         val id = dao.insert(Student(name = "Carl", surname = "", parentMobile = "", className = "", rate = 15.0))
-        dao.softDeleteStudent(id)
+        dao.softDeleteStudent(id, 0)
         val student = dao.getStudentByIdAny(id, 0).first()
         assertNotNull(student)
         assertEquals(false, student?.isActive)

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/DeleteLesson.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/lesson/DeleteLesson.kt
@@ -6,5 +6,5 @@ import javax.inject.Inject
 class DeleteLesson @Inject constructor(
     private val dao: LessonDao
 ) {
-    suspend operator fun invoke(id: Long) = dao.deleteById(id)
+    suspend operator fun invoke(id: Long, userId: Long) = dao.deleteById(id, userId)
 }

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/student/SoftDeleteStudent.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/student/SoftDeleteStudent.kt
@@ -6,5 +6,6 @@ import javax.inject.Inject
 class SoftDeleteStudent @Inject constructor(
     private val repository: StudentRepository
 ) {
-    suspend operator fun invoke(id: Long) = repository.softDeleteStudent(id)
+    suspend operator fun invoke(id: Long, userId: Long) =
+        repository.softDeleteStudent(id, userId)
 }


### PR DESCRIPTION
- WHAT changed
  - updated DAO delete queries to also filter by ownerId
  - repositories and use cases now require userId for deletions
  - view models and tests adjusted for new signatures
  - version bumped and changelog updated
- WHY it matters
  - prevents deleting other users' records
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_688526aee4588330bf50e59139598d7b