### PR TITLE
fix(student): restrict getStudentById to active records

### DIFF
--- a/data/src/main/java/gr/eduinvoice/data/repository/StudentRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/StudentRepository.kt
@@ -14,7 +14,8 @@ class StudentRepository @Inject constructor(
     suspend fun updateStudent(student: Student) = studentDao.update(student)
     suspend fun deleteStudent(student: Student) = studentDao.delete(student)
     suspend fun softDeleteStudent(studentId: Long) = studentDao.softDeleteStudent(studentId)
-    fun getStudentById(id: Long, userId: Long): Flow<Student?> = getStudentByIdAny(id, userId)
+    fun getStudentById(id: Long, userId: Long): Flow<Student?> =
+        studentDao.getStudentById(id, userId)
     fun getStudentByIdAny(id: Long, userId: Long): Flow<Student?> =
         studentDao.getStudentByIdAny(id, userId)
     fun getAllActiveStudents(userId: Long): Flow<List<Student>> =

--- a/domain/src/main/kotlin/gr/eduinvoice/domain/student/GetStudentById.kt
+++ b/domain/src/main/kotlin/gr/eduinvoice/domain/student/GetStudentById.kt
@@ -9,5 +9,5 @@ class GetStudentById @Inject constructor(
     private val repository: StudentRepository
 ) {
     operator fun invoke(id: Long, userId: Long = 0): Flow<Student?> =
-        repository.getStudentByIdAny(id, userId)
+        repository.getStudentById(id, userId)
 }


### PR DESCRIPTION
- WHAT changed
  - StudentRepository.getStudentById now calls StudentDao.getStudentById
  - GetStudentById use case delegates to repository.getStudentById
- WHY it matters
  - Clarifies that default retrieval returns only active students
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688526aef914833085b91b2fb29419a5