### PR TITLE
feat(app): set owner on insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.25] - 2025-08-25
+### App
+- Student creation now sets the `ownerId` from `CurrentUserProvider`.
+- Tests use a shared `FakeUserProvider` and verify ownership on save.
+
+## [0.21.24] - 2025-08-24
+### App
+- Student and Lessons view models retrieve the logged-in user ID on each action.
+- Tests verify user data isolation when loading or updating lessons.
+
 ## [0.21.23] - 2025-08-23
 ### Security
 - Database passphrase stored encrypted in Android Keystore.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.23"
+        versionName "0.21.25"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/gr/eduinvoice/FakeUserProvider.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/FakeUserProvider.kt
@@ -1,0 +1,10 @@
+package gr.eduinvoice
+
+import gr.eduinvoice.data.user.CurrentUserProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeUserProvider(id: Long?) : CurrentUserProvider {
+    private val _id = MutableStateFlow(id)
+    override val loggedInUserId: Flow<Long?> = _id
+}

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -19,6 +19,7 @@ import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
+import gr.eduinvoice.FakeUserProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -87,6 +88,7 @@ class StudentScreenTest {
         val studentRepo = StudentRepository(studentDao)
         val groupRepo = GroupRepository(groupDao)
         val billingRepo = TutorBillingRepository(studentDao, lessonDao, groupDao)
+        val userProvider = FakeUserProvider(1L)
         val studentUseCases = StudentUseCases(
             getActiveStudents = GetActiveStudents(studentRepo),
             getArchivedStudents = GetArchivedStudents(studentRepo),
@@ -122,7 +124,12 @@ class StudentScreenTest {
             removeStudentFromGroup = RemoveStudentFromGroup(groupRepo),
             getGroupStudents = GetGroupStudents(groupRepo)
         )
-        viewModel = StudentViewModel(studentUseCases, lessonUseCases, androidx.lifecycle.SavedStateHandle(mapOf("studentId" to 1L)))
+        viewModel = StudentViewModel(
+            studentUseCases,
+            lessonUseCases,
+            androidx.lifecycle.SavedStateHandle(mapOf("studentId" to 1L)),
+            userProvider
+        )
     }
 
     @Test

--- a/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
@@ -11,6 +11,7 @@ import gr.eduinvoice.data.model.calculateFee
 import gr.eduinvoice.domain.student.StudentUseCases
 import gr.eduinvoice.domain.lesson.LessonUseCases
 import gr.eduinvoice.data.model.Lesson
+import gr.eduinvoice.data.user.CurrentUserProvider
 import gr.eduinvoice.utils.EarningsCalculator
 import gr.eduinvoice.utils.ClassOptions
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +25,8 @@ import javax.inject.Inject
 class StudentViewModel @Inject constructor(
     private val studentUseCases: StudentUseCases,
     private val lessonUseCases: LessonUseCases,
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     val studentId: Long = savedStateHandle.get<Long>("studentId") ?: 0L
@@ -50,14 +52,14 @@ class StudentViewModel @Inject constructor(
 
     private fun loadData() {
         viewModelScope.launch {
-            combine(
-                studentUseCases.getStudentById(studentId),
-                lessonUseCases.getStudentLessons(studentId)
-            ) { student, lessons -> student to lessons }
-                .catch { e ->
-                    _uiState.update { it.copy(errorMessage = e.message) }
-                }
-                .collect { (student, lessons) ->
+            currentUserProvider.loggedInUserId.filterNotNull().flatMapLatest { uid ->
+                combine(
+                    studentUseCases.getStudentById(studentId, uid),
+                    lessonUseCases.getStudentLessons(studentId, uid)
+                ) { student, lessons -> student to lessons }
+            }.catch { e ->
+                _uiState.update { it.copy(errorMessage = e.message) }
+            }.collect { (student, lessons) ->
                     val (week, month) = student?.let { EarningsCalculator.calculate(it, lessons) } ?: (0.0 to 0.0)
                     val total = student?.let { lessons.sumOf { l -> l.calculateFee(it) } } ?: 0.0
                     _uiState.update { currentState ->
@@ -155,6 +157,7 @@ class StudentViewModel @Inject constructor(
         val className = if (state.selectedClass == "Custom") state.customClass.trim() else state.selectedClass
 
         viewModelScope.launch {
+            val userId = currentUserProvider.loggedInUserId.first() ?: return@launch
             _uiState.update { it.copy(isLoading = true) }
 
             try {
@@ -179,6 +182,7 @@ class StudentViewModel @Inject constructor(
                     )
                 } else {
                     Student(
+                        ownerId = userId,
                         name = state.name,
                         surname = state.surname,
                         parentMobile = mobile,

--- a/app/src/test/java/gr/eduinvoice/FakeUserProvider.kt
+++ b/app/src/test/java/gr/eduinvoice/FakeUserProvider.kt
@@ -1,0 +1,10 @@
+package gr.eduinvoice
+
+import gr.eduinvoice.data.user.CurrentUserProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeUserProvider(id: Long?) : CurrentUserProvider {
+    private val _id = MutableStateFlow(id)
+    override val loggedInUserId: Flow<Long?> = _id
+}

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -155,6 +155,30 @@ class LessonsViewModelTest {
         assertEquals(LessonDialog.AlreadyInvoiced(1, true), vm.uiState.value.dialog)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun updatePaidAffectsOnlyCurrentUserLesson() = runTest {
+        val today = LocalDate.now().toString()
+        val mine = LessonWithStudent(
+            Lesson(id = 1, studentId = 1, ownerId = 1, date = today, startTime = "10:00", durationMinutes = 60),
+            Student(id = 1, ownerId = 1, name = "Me", surname = "", parentMobile = "", className = "", rate = 10.0)
+        )
+        val theirs = LessonWithStudent(
+            Lesson(id = 2, studentId = 2, ownerId = 2, date = today, startTime = "11:00", durationMinutes = 60),
+            Student(id = 2, ownerId = 2, name = "You", surname = "", parentMobile = "", className = "", rate = 10.0)
+        )
+        lessonFlow.value = listOf(mine, theirs)
+
+        val vm = LessonsViewModel(lessonUseCases, userProvider)
+        advanceUntilIdle()
+
+        vm.updatePaid(1, true)
+        advanceUntilIdle()
+
+        assertEquals(true, lessonFlow.value[0].lesson.isPaid)
+        assertEquals(false, lessonFlow.value[1].lesson.isPaid)
+    }
+
     class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
         override suspend fun insert(student: Student): Long {
             flow.value = flow.value + student

--- a/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
@@ -15,6 +15,7 @@ import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
+import gr.eduinvoice.FakeUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +38,7 @@ class StudentViewModelTest {
 
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val lessonFlow = MutableStateFlow<List<Lesson>>(emptyList())
+    private val userProvider = FakeUserProvider(1L)
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val lessonDao = FakeLessonDao(lessonFlow)
@@ -72,7 +74,7 @@ class StudentViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun saveStudentClearsLoading() = runTest {
-        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 0L)))
+        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 0L)), userProvider)
         vm.updateName("Alice")
         vm.updateSurname("Smith")
         vm.updateSelectedClass("A")
@@ -80,6 +82,7 @@ class StudentViewModelTest {
         vm.saveStudent()
         advanceUntilIdle()
         assertEquals(false, vm.uiState.value.isLoading)
+        assertEquals(1L, studentFlow.value.first().ownerId)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -87,11 +90,26 @@ class StudentViewModelTest {
     fun deleteStudentClearsLoading() = runTest {
         val student = Student(id = 1, name = "Bob", surname = "", parentMobile = "", className = "A", rate = 10.0)
         studentFlow.value = listOf(student)
-        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 1L)))
+        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 1L)), userProvider)
         advanceUntilIdle()
         vm.deleteStudent()
         advanceUntilIdle()
         assertEquals(false, vm.uiState.value.isLoading)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun loadDataFiltersLessonsByUser() = runTest {
+        val student = Student(id = 1, ownerId = 1, name = "Alice", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        val otherLesson = Lesson(id = 2, ownerId = 2, studentId = 1, date = "2024-01-01", startTime = "10:00", durationMinutes = 60)
+        val myLesson = Lesson(id = 1, ownerId = 1, studentId = 1, date = "2024-01-02", startTime = "10:00", durationMinutes = 60)
+        studentFlow.value = listOf(student)
+        lessonFlow.value = listOf(myLesson, otherLesson)
+
+        val vm = StudentViewModel(studentUseCases, lessonUseCases, SavedStateHandle(mapOf("studentId" to 1L)), userProvider)
+        advanceUntilIdle()
+
+        assertEquals(listOf(myLesson), vm.uiState.value.lessons)
     }
 
     class FakeStudentDao(private val flow: MutableStateFlow<List<Student>>) : StudentDao {
@@ -104,12 +122,14 @@ class StudentViewModelTest {
         override suspend fun softDeleteStudent(studentId: Long) {
             flow.value = flow.value.filterNot { it.id == studentId }
         }
-        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> = flow.map { list -> list.find { it.id == studentId } }
-        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> = flow.asStateFlow()
+        override fun getStudentById(studentId: Long, userId: Long): Flow<Student?> =
+            flow.map { list -> list.find { it.id == studentId && it.ownerId == userId } }
+        override fun getAllActiveStudents(userId: Long): Flow<List<Student>> =
+            flow.map { list -> list.filter { it.ownerId == userId } }
         override fun getArchivedStudents(userId: Long): Flow<List<Student>> = flowOf(emptyList())
         override suspend fun restoreStudent(studentId: Long) {}
         override fun getStudentByIdAny(studentId: Long, userId: Long): Flow<Student?> = getStudentById(studentId, userId)
-        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.size
+        override suspend fun getActiveStudentCount(userId: Long): Int = flow.value.count { it.ownerId == userId }
         override suspend fun classNameExists(name: String, userId: Long): Int = flow.value.count { it.className.equals(name, true) }
     }
 
@@ -123,16 +143,20 @@ class StudentViewModelTest {
         override suspend fun deleteById(lessonId: Long) {
             flow.value = flow.value.filterNot { it.id == lessonId }
         }
-        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flow.map { list -> list.find { it.id == lessonId } }
-        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flow.map { list -> list.filter { it.studentId == studentId } }
-        override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flow.asStateFlow()
+        override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> =
+            flow.map { list -> list.find { it.id == lessonId && it.ownerId == userId } }
+        override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.studentId == studentId && it.ownerId == userId } }
+        override fun getAllLessons(userId: Long): Flow<List<Lesson>> =
+            flow.map { list -> list.filter { it.ownerId == userId } }
         override fun getLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getUnpaidLessonsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override fun getUnpaidLessonsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
         override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {}
         override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {}
-        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> = flow.map { list -> list.find { it.id == lessonId }?.isInvoiced }
+        override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> =
+            flow.map { list -> list.find { it.id == lessonId && it.ownerId == userId }?.isInvoiced }
         override fun getLessonsWithStudents(userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
@@ -149,5 +173,6 @@ class StudentViewModelTest {
         override suspend fun deleteCrossRef(groupId: Long, studentId: Long, userId: Long) {}
         override fun getStudentsForGroup(groupId: Long, userId: Long): Flow<List<Student>> = flowOf(emptyList())
     }
+
 }
 


### PR DESCRIPTION
- Student creation assigns ownerId from CurrentUserProvider
- Shared FakeUserProvider for tests
- Updated tests verifying saved owner

`./gradlew clean` (passes)
`./gradlew assemble` *(failed to complete)*
`./gradlew test` *(failed to complete)*
`./gradlew lintDebug` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68850fa707e883308d9e968a70e583a4