### PR TITLE
fix(secrets): load firebase key via env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.26] - 2025-08-26
+### Security
+- Firebase API key now loaded from environment at build time.
+
 ## [0.21.25] - 2025-08-25
 ### App
 - StudentViewModel now receives CurrentUserProvider and passes user IDs to domain use cases.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.25"
+        versionName "0.21.26"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -145,4 +145,26 @@ android {
 // Room schema location for ksp
 ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
+}
+
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+
+def firebaseKey = findProperty('FIREBASE_API_KEY') ?: System.getenv('FIREBASE_API_KEY')
+def googleServicesFile = file("$projectDir/google-services.json")
+
+tasks.register('injectFirebaseKey') {
+    doLast {
+        if (firebaseKey) {
+            def json = new JsonSlurper().parse(googleServicesFile)
+            json.client[0].api_key[0].current_key = firebaseKey
+            googleServicesFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(json))
+        }
+    }
+}
+
+tasks.whenTaskAdded { t ->
+    if (t.name.startsWith('process') && t.name.endsWith('GoogleServices')) {
+        t.dependsOn injectFirebaseKey
+    }
 }

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -12,7 +12,7 @@
         }
       },
       "api_key": [
-        {"current_key": "dummy"}
+        {"current_key": "YOUR_FIREBASE_API_KEY"}
       ],
       "services": {
         "appinvite_service": {


### PR DESCRIPTION
- WHAT changed
  - replaced value in `google-services.json` with placeholder
  - gradle task `injectFirebaseKey` reads key from properties or env and updates the json at build time
  - bumped version and documented change in CHANGELOG
- WHY it matters
  - prevents committing sensitive Firebase API key and loads it securely during builds
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688553d54ca08330b42c1fa884efc6b2