### PR TITLE
fix(.gitignore): remove duplicate pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ local.properties
 .idea/
 .vscode/  # Consider committing .vscode/settings.json if you want to share editor settings
 *.project
-.project
 .settings/
 *.sublime-workspace
 *.iml


### PR DESCRIPTION
- WHAT changed
  - Dropped redundant `.project` entry from `.gitignore`
- WHY it matters
  - Avoids duplicate ignores for Eclipse projects
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_6885cb39d5a083308eb5f99afcd6820c