### PR TITLE
fix(invoice): handle file operation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.28] - 2025-08-28
+### App
+- Invoice actions now show errors if PDF generation or file operations fail.
+
 ## [0.21.27] - 2025-08-27
 ### Build
 - Gradle wrapper memory options increased to 512m.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.27"
+        versionName "0.21.28"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
@@ -38,6 +38,10 @@ import gr.eduinvoice.utils.getFullName
 import androidx.compose.ui.graphics.toArgb
 import gr.eduinvoice.ui.settings.SettingsViewModel
 import gr.eduinvoice.ui.profile.ProfileViewModel
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarHost
 import java.io.File
 import java.io.FileOutputStream
 import java.time.LocalDate
@@ -68,6 +72,8 @@ fun InvoiceScreen(
     val context = LocalContext.current
     var showConfirm by remember { mutableStateOf(false) }
     var generatedInvoice by remember { mutableStateOf<Uri?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     Scaffold(
         topBar = {
@@ -80,6 +86,7 @@ fun InvoiceScreen(
                 }
             )
         },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         bottomBar = {
             Row(
                 modifier = Modifier
@@ -146,9 +153,13 @@ fun InvoiceScreen(
                             tutorAddress = user?.subjectSpecialty ?: "",
                             currencySymbol = settings.currencySymbol
                         )
-                        viewModel.markAsPaid(selected.map { it.lesson.id })
-                        generatedInvoice = uri
-                        showConfirm = false
+                        if (uri != null) {
+                            viewModel.markAsPaid(selected.map { it.lesson.id })
+                            generatedInvoice = uri
+                            showConfirm = false
+                        } else {
+                            scope.launch { snackbarHostState.showSnackbar("Failed to create invoice") }
+                        }
                     }) { Text("Create") }
                 },
                 dismissButton = {
@@ -261,7 +272,7 @@ fun createInvoicePdf(
     tutorName: String = "Tutor Name",
     tutorAddress: String = "123 Education Lane",
     currencySymbol: String = "€"
-): Uri {
+): Uri? {
     val pdf = android.graphics.pdf.PdfDocument()
     val width = 595
     val pageInfo = android.graphics.pdf.PdfDocument.PageInfo.Builder(width, 842, 1).create()
@@ -319,13 +330,18 @@ fun createInvoicePdf(
     y += 25
     canvas.drawText("Total: $currencySymbol%.2f".format(total), width - 120f, y.toFloat(), infoPaint)
 
-    pdf.finishPage(page)
-    if (!directory.exists()) directory.mkdirs()
-    val file = File(directory, "invoice-$invoiceNumber.pdf")
-    FileOutputStream(file).use { pdf.writeTo(it) }
-    pdf.close()
-    logo.recycle()
-    return FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
+    return try {
+        pdf.finishPage(page)
+        if (!directory.exists() && !directory.mkdirs()) throw java.io.IOException("Could not create directory")
+        val file = File(directory, "invoice-$invoiceNumber.pdf")
+        FileOutputStream(file).use { pdf.writeTo(it) }
+        FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
+    } catch (e: Exception) {
+        null
+    } finally {
+        pdf.close()
+        logo.recycle()
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/gr/eduinvoice/ui/invoice/PastInvoicesScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/invoice/PastInvoicesScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import gr.eduinvoice.utils.archiveInvoice
 import gr.eduinvoice.utils.deleteInvoice
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
 import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -30,6 +32,8 @@ fun PastInvoicesScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     val invoicesDir = remember { File(context.filesDir, "invoices") }
     var invoices by remember { mutableStateOf<List<File>>(emptyList()) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     fun refresh() {
         invoices = invoicesDir.listFiles()?.sortedByDescending { it.lastModified() } ?: emptyList()
@@ -49,7 +53,8 @@ fun PastInvoicesScreen(onBack: () -> Unit) {
                     }
                 }
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { padding ->
         if (invoices.isEmpty()) {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
@@ -77,17 +82,27 @@ fun PastInvoicesScreen(onBack: () -> Unit) {
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.archive_invoice)) },
                                     onClick = {
-                                        archiveInvoice(file)
-                                        expanded = false
-                                        refresh()
+                                        try {
+                                            archiveInvoice(file)
+                                            refresh()
+                                        } catch (e: Exception) {
+                                            scope.launch { snackbarHostState.showSnackbar("Failed to archive invoice") }
+                                        } finally {
+                                            expanded = false
+                                        }
                                     }
                                 )
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.delete_invoice)) },
                                     onClick = {
-                                        deleteInvoice(file)
-                                        expanded = false
-                                        refresh()
+                                        try {
+                                            deleteInvoice(file)
+                                            refresh()
+                                        } catch (e: Exception) {
+                                            scope.launch { snackbarHostState.showSnackbar("Failed to delete invoice") }
+                                        } finally {
+                                            expanded = false
+                                        }
                                     }
                                 )
                             }


### PR DESCRIPTION
- WHAT changed
  - Added exception handling in `createInvoicePdf` to catch file errors and close documents
  - Wrapped archive/delete actions with try/catch in `PastInvoicesScreen`
  - Added snackbar messages for failures
  - Bumped version to 0.21.28 and updated changelog
- WHY it matters
  - Prevents app crashes during PDF generation or file operations
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688619bd56f48330a7e1f26c057c01d4