### PR TITLE
fix(app): specific db exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.28] - 2025-08-28
+### Fix
+- Replaced broad `Exception` catches with specific types for better error handling.
+
 ## [0.21.27] - 2025-08-27
 ### Build
 - Gradle wrapper memory options increased to 512m.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.27"
+        versionName "0.21.28"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/student/StudentViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.util.Patterns
+import android.database.sqlite.SQLiteException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -205,11 +206,18 @@ class StudentViewModel @Inject constructor(
                     _uiState.update { it.copy(isLoading = false) }
                     onNavigateBack?.invoke()
                 }
-            } catch (e: Exception) {
+            } catch (e: IllegalArgumentException) {
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        errorMessage = "Failed to save student: ${e.message}"
+                        errorMessage = "Invalid student data: ${e.message}"
+                    )
+                }
+            } catch (e: SQLiteException) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Database error while saving student: ${e.message}"
                     )
                 }
             }
@@ -231,11 +239,18 @@ class StudentViewModel @Inject constructor(
                         onNavigateBack?.invoke()
                     }
                 }
-            } catch (e: Exception) {
+            } catch (e: SQLiteException) {
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        errorMessage = "Failed to delete student: ${e.message}"
+                        errorMessage = "Database error while deleting student: ${e.message}"
+                    )
+                }
+            } catch (e: IllegalArgumentException) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Invalid request to delete student: ${e.message}"
                     )
                 }
             }

--- a/app/src/main/java/gr/eduinvoice/utils/PdfFilePrintAdapter.kt
+++ b/app/src/main/java/gr/eduinvoice/utils/PdfFilePrintAdapter.kt
@@ -10,6 +10,7 @@ import android.print.PageRange
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.IOException
 
 class PdfFilePrintAdapter(private val context: Context, private val file: File) : PrintDocumentAdapter() {
     override fun onLayout(
@@ -43,8 +44,8 @@ class PdfFilePrintAdapter(private val context: Context, private val file: File) 
                 }
             }
             callback.onWriteFinished(arrayOf(PageRange.ALL_PAGES))
-        } catch (e: Exception) {
-            callback.onWriteFailed(e.message)
+        } catch (e: IOException) {
+            callback.onWriteFailed("Failed to write PDF: ${e.message}")
         }
     }
 }


### PR DESCRIPTION
- WHAT changed
  - replaced `catch (e: Exception)` with specific exception types
  - updated error messages for database and invalid data errors
  - bumped version and changelog
- WHY it matters
  - narrow exceptions offer clearer failure info and avoid swallowing bugs
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688619c7ba548330951ff3d096e35761