### PR TITLE
fix(app): disable backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.29] - 2025-08-29
+### Security
+- Disabled Android backup by setting `android:allowBackup="false"` to protect user data.
+
 ## [0.21.28] - 2025-08-28
 ### Fix
 - Replaced broad `Exception` catches with specific types for better error handling.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.28"
+        versionName "0.21.29"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <application
         android:name=".TutorBillingApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
- WHAT changed
  - disable `android:allowBackup` in manifest
  - bump versionName to 0.21.29 and document in changelog
- WHY it matters
  - prevents accidental user data leakage through device backups
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_6886197cc8b88330a9aae280afdfcf03