### PR TITLE
feat(invoice): validate date range and use constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.29] - 2025-08-29
+### Feat
+- Lesson duration limits now use `MIN_DURATION` and `MAX_DURATION` constants.
+- Invoice date pickers validate the selected range and show errors when invalid.
+
 ## [0.21.28] - 2025-08-28
 ### Fix
 - Replaced broad `Exception` catches with specific types for better error handling.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.28"
+        versionName "0.21.29"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
@@ -70,10 +70,18 @@ fun InvoiceScreen(
     val settings = settingsState.settings
     val user = profileState.user
     val context = LocalContext.current
+    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
     var showConfirm by remember { mutableStateOf(false) }
     var generatedInvoice by remember { mutableStateOf<Uri?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let { msg ->
+            snackbarHostState.showSnackbar(msg)
+            viewModel.dismissError()
+        }
+    }
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceViewModel.kt
@@ -46,6 +46,11 @@ class InvoiceViewModel @Inject constructor(
     private val _selectedLessons = MutableStateFlow<Set<Long>>(emptySet())
     val selectedLessons: StateFlow<Set<Long>> = _selectedLessons.asStateFlow()
 
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    fun dismissError() { _errorMessage.value = null }
+
     init {
         defaultStudentId?.let { _selectedStudentId.value = it }
         viewModelScope.launch {
@@ -66,8 +71,21 @@ class InvoiceViewModel @Inject constructor(
         }
     }
 
-    fun updateStartDate(date: LocalDate) { _startDate.value = date }
-    fun updateEndDate(date: LocalDate) { _endDate.value = date }
+    fun updateStartDate(date: LocalDate) {
+        if (date <= _endDate.value) {
+            _startDate.value = date
+        } else {
+            _errorMessage.value = "Start date must be on or before end date"
+        }
+    }
+
+    fun updateEndDate(date: LocalDate) {
+        if (date >= _startDate.value) {
+            _endDate.value = date
+        } else {
+            _errorMessage.value = "End date must be on or after start date"
+        }
+    }
     fun selectStudent(id: Long) { _selectedStudentId.value = id }
 
     fun toggleLesson(id: Long) {

--- a/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lesson/LessonViewModel.kt
@@ -29,6 +29,11 @@ class LessonViewModel @Inject constructor(
     private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
+    companion object {
+        const val MIN_DURATION = 60
+        const val MAX_DURATION = 180
+    }
+
     private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
@@ -124,7 +129,7 @@ class LessonViewModel @Inject constructor(
 
     fun updateDuration(duration: String) {
         val digits = duration.filter { it.isDigit() }
-        val number = digits.toIntOrNull()?.coerceIn(0, 180) ?: 0
+        val number = digits.toIntOrNull()?.coerceIn(0, MAX_DURATION) ?: 0
         val sanitized = number.takeIf { it > 0 }?.toString() ?: ""
         _uiState.update { it.copy(durationMinutes = sanitized) }
     }
@@ -193,7 +198,7 @@ class LessonViewModel @Inject constructor(
             hasStudent && validDateTime
         } else {
             val duration = state.durationMinutes.toIntOrNull() ?: 0
-            hasStudent && validDateTime && duration in 60..180
+            hasStudent && validDateTime && duration in MIN_DURATION..MAX_DURATION
         }
     }
 
@@ -206,11 +211,11 @@ class LessonViewModel @Inject constructor(
             val state = _uiState.value
             var duration = state.durationMinutes.toIntOrNull() ?: 0
             if (state.rateType == RateTypes.PER_LESSON) {
-                duration = 60
+                duration = MIN_DURATION
             } else {
-                if (duration <= 0) duration = 60
-                if (duration < 60) duration = 60
-                if (duration > 180) duration = 180
+                if (duration <= 0) duration = MIN_DURATION
+                if (duration < MIN_DURATION) duration = MIN_DURATION
+                if (duration > MAX_DURATION) duration = MAX_DURATION
                 _uiState.update { it.copy(durationMinutes = duration.toString()) }
             }
             if (!isFormValid()) return@launch
@@ -283,13 +288,13 @@ class LessonViewModel @Inject constructor(
                 if (state.rateType == RateTypes.PER_LESSON) {
                     student.rate
                 } else {
-                    (duration.coerceAtLeast(60) / 60.0) * student.rate
+                    (duration.coerceAtLeast(MIN_DURATION) / 60.0) * student.rate
                 }
             }
         } else if (state.rateType == RateTypes.PER_LESSON) {
             state.studentRate
         } else {
-            (duration.coerceAtLeast(60) / 60.0) * state.studentRate
+            (duration.coerceAtLeast(MIN_DURATION) / 60.0) * state.studentRate
         }
     }
 }


### PR DESCRIPTION
- WHAT changed
  - Added `MIN_DURATION` and `MAX_DURATION` constants in `LessonViewModel`
  - Replaced hard-coded duration values with these constants
  - InvoiceViewModel now validates start/end dates and exposes error messages
  - InvoiceScreen displays these errors via Snackbar
  - Bumped version to 0.21.29 and updated changelog
- WHY it matters
  - Keeps lesson duration rules consistent and easier to adjust
  - Prevents illogical invoice date ranges and informs the user immediately
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_68861fa514e88330af9df9042b510e68