### PR TITLE
refactor(invoice): extract PDF helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.29] - 2025-08-29
+### Refactor
+- Extracted PDF rendering steps into helper functions for clarity.
+- Added unit tests ensuring invoices are written to disk.
+
 ## [0.21.28] - 2025-08-28
 ### Fix
 - Replaced broad `Exception` catches with specific types for better error handling.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 19
-        versionName "0.21.28"
+        versionName "0.21.29"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/invoice/InvoiceScreen.kt
@@ -279,9 +279,64 @@ fun createInvoicePdf(
     val page = pdf.startPage(pageInfo)
     val canvas = page.canvas
 
-    val headerPaint = android.graphics.Paint().apply {
-        color = colorScheme.primary.toArgb()
+    val infoPaint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        color = colorScheme.onBackground.toArgb()
+        textSize = typography.titleMedium.fontSize.value * 2
     }
+    val logo = drawInvoiceHeader(
+        context,
+        canvas,
+        width,
+        invoiceNumber,
+        colorScheme,
+        typography,
+        infoPaint,
+        tutorName,
+        tutorAddress
+    )
+
+    val linePaint = android.graphics.Paint().apply {
+        color = colorScheme.outline.toArgb()
+        strokeWidth = 1f
+    }
+    val textPaint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        color = colorScheme.onBackground.toArgb()
+        textSize = typography.bodyMedium.fontSize.value * 2
+    }
+
+    val (y, total) = drawInvoiceRows(
+        canvas,
+        lessons,
+        110,
+        width,
+        infoPaint,
+        textPaint,
+        linePaint,
+        currencySymbol
+    )
+
+    canvas.drawText(
+        "Total: $currencySymbol%.2f".format(total),
+        width - 120f,
+        (y + 25).toFloat(),
+        infoPaint
+    )
+
+    return writePdfToFile(context, pdf, page, logo, directory, invoiceNumber)
+}
+
+private fun drawInvoiceHeader(
+    context: android.content.Context,
+    canvas: android.graphics.Canvas,
+    width: Int,
+    invoiceNumber: String,
+    colorScheme: androidx.compose.material3.ColorScheme,
+    typography: androidx.compose.material3.Typography,
+    infoPaint: android.graphics.Paint,
+    tutorName: String,
+    tutorAddress: String,
+): android.graphics.Bitmap {
+    val headerPaint = android.graphics.Paint().apply { color = colorScheme.primary.toArgb() }
     canvas.drawRect(0f, 0f, width.toFloat(), 80f, headerPaint)
     val logo = android.graphics.BitmapFactory.decodeResource(context.resources, R.drawable.tutorbilling_logo)
     canvas.drawBitmap(logo, 20f, 10f, null)
@@ -293,29 +348,27 @@ fun createInvoicePdf(
     }
     canvas.drawText(tutorName, 100f, 40f, titlePaint)
     canvas.drawText(tutorAddress, 100f, 60f, titlePaint)
-
-    val infoPaint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
-        color = colorScheme.onBackground.toArgb()
-        textSize = typography.titleMedium.fontSize.value * 2
-    }
     canvas.drawText("Invoice #$invoiceNumber", width - 200f, 40f, infoPaint)
+    return logo
+}
 
-    var y = 110
-    val linePaint = android.graphics.Paint().apply {
-        color = colorScheme.outline.toArgb()
-        strokeWidth = 1f
-    }
-    val textPaint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
-        color = colorScheme.onBackground.toArgb()
-        textSize = typography.bodyMedium.fontSize.value * 2
-    }
+private fun drawInvoiceRows(
+    canvas: android.graphics.Canvas,
+    lessons: List<LessonWithStudent>,
+    startY: Int,
+    width: Int,
+    infoPaint: android.graphics.Paint,
+    textPaint: android.graphics.Paint,
+    linePaint: android.graphics.Paint,
+    currencySymbol: String
+): Pair<Int, Double> {
+    var y = startY
     canvas.drawText("Date", 40f, y.toFloat(), infoPaint)
     canvas.drawText("Student", 180f, y.toFloat(), infoPaint)
     canvas.drawText("Amount", width - 120f, y.toFloat(), infoPaint)
     y += 10
     canvas.drawLine(40f, y.toFloat(), width - 40f, y.toFloat(), linePaint)
     y += 20
-
     var total = 0.0
     lessons.forEach { item ->
         canvas.drawText(item.lesson.date, 40f, y.toFloat(), textPaint)
@@ -327,9 +380,17 @@ fun createInvoicePdf(
     }
     y += 10
     canvas.drawLine(40f, y.toFloat(), width - 40f, y.toFloat(), linePaint)
-    y += 25
-    canvas.drawText("Total: $currencySymbol%.2f".format(total), width - 120f, y.toFloat(), infoPaint)
+    return y to total
+}
 
+private fun writePdfToFile(
+    context: android.content.Context,
+    pdf: android.graphics.pdf.PdfDocument,
+    page: android.graphics.pdf.PdfDocument.Page,
+    logo: android.graphics.Bitmap,
+    directory: File,
+    invoiceNumber: String
+): Uri? {
     return try {
         pdf.finishPage(page)
         if (!directory.exists() && !directory.mkdirs()) throw java.io.IOException("Could not create directory")

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
@@ -1,0 +1,34 @@
+package gr.eduinvoice.ui.invoice
+
+import android.content.Context
+import androidx.compose.material3.Typography
+import androidx.compose.material3.lightColorScheme
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.LessonWithStudent
+import gr.eduinvoice.data.model.Lesson
+import gr.eduinvoice.data.model.Student
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class InvoicePdfTest {
+    @Test
+    fun createInvoicePdfWritesToFile() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dir = kotlin.io.path.createTempDirectory().toFile()
+        val lesson = Lesson(id = 1, studentId = 1, date = "2024-01-01", startTime = "10:00", durationMinutes = 60)
+        val student = Student(id = 1, name = "Bob", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        val lessons = listOf(LessonWithStudent(lesson, student))
+
+        val uri = createInvoicePdf(context, dir, lessons, "001", lightColorScheme(), Typography())
+
+        val file = File(dir, "invoice-001.pdf")
+        assertNotNull(uri)
+        assertTrue(file.exists())
+        assertTrue(file.length() > 0)
+    }
+}


### PR DESCRIPTION
- WHAT changed
  - split PDF rendering into header, row, and file helpers
  - bumped app version and documented change
  - added unit test verifying PDF creation
- WHY it matters
  - smaller `createInvoicePdf` is easier to maintain
  - tests guard PDF builder logic
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_68861f9144348330b224843b4cff4149