### PR TITLE
docs(versioning): adopt semantic versioning policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,9 @@ Checklist:
 5. **Robolectric memory leaks** – never keep global state in test classes; use `@Config` with `sdk = 34`.
 
 ## 8. Changelog
-Update `CHANGELOG.md` by creating a new `[0.x]` section dated for your pull request. Bump `versionName` in `app/build.gradle` to match (current version is `0.21.12`).
+Keep `CHANGELOG.md` in Semantic Version format. Bump `versionName` in
+`app/build.gradle` only when making a release (patch, minor or major).
+The current version is `0.22.0`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.22] - 2025-07-26
+## [0.22.0] - 2025-07-26
 ### Feature: Hardened Security
 - Improved data protection by disabling Android's automatic backup feature (`android:allowBackup="false"`).
 - Enhanced build security by loading the Firebase API key from a secure environment variable.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ When you modify an entity schema:
 ## Changelog
 
 A high level summary of changes lives in [`CHANGELOG.md`](CHANGELOG.md).
-This project is still unreleased and currently version `0.21.12`. Each
-pull request should bump the version to the next `0.x` value and add a
-changelog entry before merge.
+Starting with version `0.22.0`, releases follow Semantic Versioning
+(MAJOR.MINOR.PATCH). The current version is `0.22.0`.
+Bump the version only when preparing a release and update the changelog
+accordingly.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 19
-        versionName "0.21.29"
+        versionCode 20
+        versionName "0.22.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
- document new semantic versioning policy in README
- update AGENTS guidance for changelog/versioning
- bump version in build.gradle to 0.22.0
- rename latest changelog header to 0.22.0

## Testing
- `./gradlew clean` *(fails: Directory does not exist for Android SDK)*
- `./gradlew assemble` *(fails: sdk.dir property in local.properties does not exist)*
- `./gradlew test` *(fails: sdk.dir property in local.properties does not exist)*
- `./gradlew lintDebug` *(fails: configuration on demand warning)*

------
https://chatgpt.com/codex/tasks/task_e_688629c1bf1483308bcd69b166cc7111