### PR TITLE
fix(docs): document firebase api key injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.2] - 2025-07-28
+### Build/CI
+- Documented `FIREBASE_API_KEY` usage for injecting Firebase credentials.
+
 ## [0.22.1] - 2025-07-27
 ### Added
 - Instrumentation tests for Settings screen flows.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ java -version
 
 Running the script once will download the command line tools and create a `local.properties` file pointing Gradle to the SDK. Make sure to source your profile before invoking any Gradle tasks so that the `ANDROID_HOME` variables are available.
 
+## Firebase API key
+
+The included `app/google-services.json` only contains a placeholder key. Provide the real Firebase API key at build time via the `FIREBASE_API_KEY` environment variable. Never commit actual keys to version control.
+
 ## Building the project
 
 Use the Gradle wrapper to build, lint and test the app. Run the commands in this


### PR DESCRIPTION
- document FIREBASE_API_KEY environment variable in README
- add CHANGELOG entry for 0.22.2

Tested:
- `./gradlew clean` ✅
- `./gradlew assemble` ✅
- `./gradlew test` ❌ (compilation errors in InvoicePdfTest)
- `./gradlew lintDebug` ✅

------
https://chatgpt.com/codex/tasks/task_e_688a22c9d008833099a5baee63b7ae2b