### PR TITLE
fix(backup): validate schema restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.2] - 2025-07-28
+### Fixed
+- Backup restore now validates JSON schema and reports errors to the caller.
+
 ## [0.22.1] - 2025-07-27
 ### Added
 - Instrumentation tests for Settings screen flows.

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import kotlinx.coroutines.launch
+import androidx.compose.material3.SnackbarHostState
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.R
@@ -39,6 +40,7 @@ fun SettingsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
     val exportLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("application/json")
     ) { uri ->
@@ -58,13 +60,20 @@ fun SettingsScreen(
             scope.launch {
                 context.contentResolver.openInputStream(it)?.use { ins ->
                     val json = ins.readBytes().decodeToString()
-                    viewModel.restoreBackup(json)
+                    val success = viewModel.restoreBackup(json)
+                    val msg = if (success) {
+                        context.getString(R.string.backup_restored)
+                    } else {
+                        context.getString(R.string.invalid_backup)
+                    }
+                    snackbarHostState.showSnackbar(msg)
                 }
             }
         }
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
             AppTopBar(
                 title = stringResource(R.string.settings),

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -63,7 +63,7 @@ class SettingsViewModel @Inject constructor(
 
     suspend fun exportBackup(): String = backupRepository.exportJson()
 
-    fun restoreBackup(json: String) {
-        viewModelScope.launch { backupRepository.restoreFromJson(json) }
+    suspend fun restoreBackup(json: String): Boolean {
+        return backupRepository.restoreFromJson(json).isSuccess
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,4 +116,6 @@
     <string name="edit_profile">Edit Profile</string>
     <string name="backup_export">Export Backup</string>
     <string name="backup_restore">Restore Backup</string>
+    <string name="backup_restored">Backup restored</string>
+    <string name="invalid_backup">Invalid backup file</string>
 </resources>

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
@@ -11,8 +11,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.File
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class InvoicePdfTest {

--- a/data/src/main/java/gr/eduinvoice/data/repository/BackupRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/BackupRepository.kt
@@ -7,6 +7,7 @@ import gr.eduinvoice.data.database.EduInvoiceDatabase
 import gr.eduinvoice.data.model.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -86,19 +87,29 @@ class BackupRepository @Inject constructor(
         return Json.encodeToString(BackupDump.serializer(), dump)
     }
 
-    suspend fun restoreFromJson(json: String) {
-        val dump = Json.decodeFromString(BackupDump.serializer(), json)
-        db.withTransaction {
-            db.clearAllTables()
-            val studentDao = db.studentDao()
-            val lessonDao = db.lessonDao()
-            val groupDao = db.groupDao()
-            val userDao = db.userDao()
-            dump.users.forEach { userDao.insert(it) }
-            dump.students.forEach { studentDao.insert(it) }
-            dump.groups.forEach { groupDao.insertGroup(it) }
-            dump.crossRefs.forEach { groupDao.insertCrossRef(it) }
-            dump.lessons.forEach { lessonDao.insert(it) }
+    suspend fun restoreFromJson(json: String): Result<Unit> {
+        return try {
+            val element = Json.parseToJsonElement(json).jsonObject
+            val required = listOf("students", "lessons", "groups", "crossRefs", "users")
+            if (!required.all { element.containsKey(it) }) {
+                return Result.failure(IllegalArgumentException("Backup JSON missing required fields"))
+            }
+            val dump = Json.decodeFromString(BackupDump.serializer(), json)
+            db.withTransaction {
+                db.clearAllTables()
+                val studentDao = db.studentDao()
+                val lessonDao = db.lessonDao()
+                val groupDao = db.groupDao()
+                val userDao = db.userDao()
+                dump.users.forEach { userDao.insert(it) }
+                dump.students.forEach { studentDao.insert(it) }
+                dump.groups.forEach { groupDao.insertGroup(it) }
+                dump.crossRefs.forEach { groupDao.insertCrossRef(it) }
+                dump.lessons.forEach { lessonDao.insert(it) }
+            }
+            Result.success(Unit)
+        } catch (e: kotlinx.serialization.SerializationException) {
+            Result.failure(e)
         }
     }
 }

--- a/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
@@ -39,9 +39,16 @@ class BackupRepositoryTest {
         db.studentDao().insert(Student(name = "Test", surname = "", parentMobile = "", className = "A", rate = 10.0))
         val json = repo.exportJson()
         db.clearAllTables()
-        repo.restoreFromJson(json)
+        val result = repo.restoreFromJson(json)
+        assert(result.isSuccess)
         val students = db.studentDao().getAllActiveStudents(0).first()
         assertEquals(1, students.size)
         assertEquals("Test", students.first().name)
+    }
+
+    @Test
+    fun restoreFailsOnInvalidJson() = runBlocking {
+        val result = repo.restoreFromJson("{}")
+        assert(result.isFailure)
     }
 }


### PR DESCRIPTION
- WHAT changed
  - added JSON schema validation and `Result` return in `BackupRepository`
  - propagated success info through `SettingsViewModel` and UI
  - surfaced snackbar messages on restore outcome
  - updated tests and strings
- WHY it matters
  - prevents corrupt backups from wiping data and lets UI show errors
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_688a22c5ef1483308bb539ada10a77f5