### PR TITLE
feat(user): add login and registration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.3] - 2025-07-29
+### Added
+- Unit tests for login and registration flows verifying preferences updates.
+- Backup restore now validates JSON before parsing.
+
 ## [0.22.2] - 2025-07-28
 ### Fixed
 - Backup restore now validates JSON schema and reports errors to the caller.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 20
-        versionName "0.22.2"
+        versionName "0.22.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -137,6 +137,7 @@ android {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
     implementation platform('com.google.firebase:firebase-bom:33.15.0')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-crashlytics:19.4.4'

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -69,18 +70,16 @@ class SettingsViewModel @Inject constructor(
     suspend fun exportBackup(): String = backupRepository.exportJson()
 
     suspend fun restoreBackup(json: String): Boolean {
-        return backupRepository.restoreFromJson(json).isSuccess
-
-      fun restoreBackup(json: String) {
-        viewModelScope.launch {
-            try {
-                backupRepository.restoreFromJson(json)
-            } catch (e: SerializationException) {
-                _errorMessage.value = "Invalid backup data: ${e.message}".trim()
-            } catch (e: SQLiteException) {
-                _errorMessage.value =
-                    "Database error while restoring backup: ${e.message}".trim()
-            }
+        return try {
+            Json.parseToJsonElement(json)
+            backupRepository.restoreFromJson(json).isSuccess
+        } catch (e: SerializationException) {
+            _errorMessage.value = "Invalid backup data: ${e.message}".trim()
+            false
+        } catch (e: SQLiteException) {
+            _errorMessage.value =
+                "Database error while restoring backup: ${e.message}".trim()
+            false
         }
     }
 

--- a/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
@@ -1,0 +1,80 @@
+package gr.eduinvoice.ui.user
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.MainDispatcherRule
+import gr.eduinvoice.data.dao.UserDao
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import gr.eduinvoice.domain.user.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoginViewModelTest {
+    @get:Rule val dispatcherRule = MainDispatcherRule()
+
+    private val storedUser = User(
+        id = 1,
+        username = "bob",
+        passwordHash = gr.eduinvoice.data.repository.PasswordHasher.hash("pass"),
+        fullName = "Bob"
+    )
+
+    private val userDao = object : UserDao {
+        override suspend fun insert(user: User) = 0L
+        override suspend fun update(user: User) {}
+        override suspend fun delete(user: User) {}
+        override fun getUserById(id: Long): Flow<User?> = flowOf(storedUser.takeIf { it.id == id })
+        override suspend fun getByUsername(username: String): User? = storedUser.takeIf { it.username == username }
+    }
+    private val userRepo = UserRepository(userDao)
+    private val useCases = UserUseCases(
+        createUser = CreateUser(userRepo),
+        authenticateUser = AuthenticateUser(userRepo),
+        getUserProfile = GetUserProfile(userRepo),
+        updateUser = UpdateUser(userRepo),
+        resetPassword = ResetPassword(userRepo)
+    )
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val prefs = UserPreferencesRepository(context)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun successfulLoginUpdatesPrefs() = runTest {
+        val vm = LoginViewModel(useCases, prefs)
+        vm.updateUsername("bob")
+        vm.updatePassword("pass")
+        var callbackId: Long? = null
+        vm.login { callbackId = it }
+        advanceUntilIdle()
+        assertEquals(1L, prefs.loggedInUserId.first())
+        assertEquals(1L, callbackId)
+        assertNull(vm.uiState.value.error)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun failedLoginSetsError() = runTest {
+        val vm = LoginViewModel(useCases, prefs)
+        vm.updateUsername("bob")
+        vm.updatePassword("wrong")
+        var called = false
+        vm.login { called = true }
+        advanceUntilIdle()
+        assertNull(prefs.loggedInUserId.first())
+        assertEquals(false, called)
+        assertEquals("Invalid credentials", vm.uiState.value.error)
+    }
+}

--- a/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
@@ -1,0 +1,95 @@
+package gr.eduinvoice.ui.user
+
+import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.MainDispatcherRule
+import gr.eduinvoice.data.dao.UserDao
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.repository.UserRepository
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import gr.eduinvoice.domain.user.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RegisterViewModelTest {
+    @get:Rule val dispatcherRule = MainDispatcherRule()
+
+    private class FakeUserDao : UserDao {
+        val users = mutableListOf<User>()
+        override suspend fun insert(user: User): Long {
+            if (users.any { it.username == user.username }) {
+                throw SQLiteConstraintException("username exists")
+            }
+            users += user
+            return (users.indexOf(user) + 1).toLong()
+        }
+        override suspend fun update(user: User) {}
+        override suspend fun delete(user: User) {}
+        override fun getUserById(id: Long): Flow<User?> = flowOf(users.find { it.id == id })
+        override suspend fun getByUsername(username: String): User? = users.find { it.username == username }
+    }
+
+    private val userDao = FakeUserDao()
+    private val repo = UserRepository(userDao)
+    private val useCases = UserUseCases(
+        createUser = CreateUser(repo),
+        authenticateUser = AuthenticateUser(repo),
+        getUserProfile = GetUserProfile(repo),
+        updateUser = UpdateUser(repo),
+        resetPassword = ResetPassword(repo)
+    )
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val prefs = UserPreferencesRepository(context)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun successfulRegistrationUpdatesPrefs() = runTest {
+        val vm = RegisterViewModel(useCases, prefs)
+        vm.updateUsername("alice")
+        vm.updatePassword("secret")
+        vm.updateFullName("Alice")
+        vm.updateSubjectSpecialty("Math")
+        vm.updateYearsExperience("1")
+        var called = false
+        vm.register { called = true }
+        advanceUntilIdle()
+        assertEquals(1L, prefs.loggedInUserId.first())
+        assertEquals(true, called)
+        assertNull(vm.uiState.value.error)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun duplicateUsernameShowsError() = runTest {
+        userDao.users += User(
+            id = 1,
+            username = "bob",
+            passwordHash = "x",
+            fullName = "Bob",
+            subjectSpecialty = "Math",
+            yearsExperience = 2
+        )
+        val vm = RegisterViewModel(useCases, prefs)
+        vm.updateUsername("bob")
+        vm.updatePassword("secret")
+        vm.updateFullName("Bob")
+        vm.updateSubjectSpecialty("Math")
+        vm.updateYearsExperience("2")
+        vm.register {}
+        advanceUntilIdle()
+        assertNull(prefs.loggedInUserId.first())
+        assertEquals("Username already exists", vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
- Added unit tests for LoginViewModel and RegisterViewModel verifying successful and failed flows.
- Backup restore now validates JSON before processing and surfaces errors.
- Bumped version to 0.22.3 and updated changelog.

Test steps:
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: MavenArtifactFetcher network issue)*
- `./gradlew lintDebug`

------
https://chatgpt.com/codex/tasks/task_e_688a3173d2d48330b81b545205c89d16