### PR TITLE
fix(home): scope home menu to current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.3] - 2025-07-30
+### Fixed
+- Home screen now scopes data to the logged-in user.
+
 ## [0.22.2] - 2025-07-28
 ### Fixed
 - Backup restore now validates JSON schema and reports errors to the caller.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 20
-        versionName "0.22.2"
+        versionName "0.22.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
@@ -22,6 +22,7 @@ import gr.eduinvoice.domain.student.*
 import gr.eduinvoice.domain.user.*
 import gr.eduinvoice.ui.home.HomeMenuScreen
 import gr.eduinvoice.ui.home.HomeMenuViewModel
+import gr.eduinvoice.FakeUserProvider
 import gr.eduinvoice.ui.user.LoginScreen
 import gr.eduinvoice.ui.user.LoginViewModel
 import gr.eduinvoice.ui.welcome.WelcomeScreen
@@ -222,7 +223,7 @@ class SettingsScreenFlowTest {
             updateLessonInvoicedStatus = UpdateLessonInvoicedStatus(lessonDao),
             isLessonInvoiced = IsLessonInvoiced(lessonDao)
         )
-        val homeVm = HomeMenuViewModel(studentUseCases, lessonUseCases)
+        val homeVm = HomeMenuViewModel(studentUseCases, lessonUseCases, FakeUserProvider(1L))
         composeRule.setContent {
             val showSettings = remember { mutableStateOf(false) }
             if (showSettings.value) {

--- a/app/src/main/java/gr/eduinvoice/ui/home/HomeMenuViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/home/HomeMenuViewModel.kt
@@ -6,10 +6,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.model.calculateFee
 import gr.eduinvoice.domain.lesson.LessonUseCases
 import gr.eduinvoice.domain.student.StudentUseCases
+import gr.eduinvoice.data.user.CurrentUserProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -19,7 +22,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeMenuViewModel @Inject constructor(
     private val studentUseCases: StudentUseCases,
-    private val lessonUseCases: LessonUseCases
+    private val lessonUseCases: LessonUseCases,
+    private val currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeMenuUiState())
@@ -27,15 +31,16 @@ class HomeMenuViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            combine(
-                studentUseCases.getActiveStudents(),
-                lessonUseCases.getAllLessons()
-            ) { students, lessons ->
-                val classCount = students
-                    .map { it.className }
-                    .filterNot { it.isBlank() || it.equals("unknown", true) }
-                    .distinct()
-                    .size
+            currentUserProvider.loggedInUserId.filterNotNull().flatMapLatest { uid ->
+                combine(
+                    studentUseCases.getActiveStudents(uid),
+                    lessonUseCases.getAllLessons(uid)
+                ) { students, lessons ->
+                    val classCount = students
+                        .map { it.className }
+                        .filterNot { it.isBlank() || it.equals("unknown", true) }
+                        .distinct()
+                        .size
 
                 val today = LocalDate.now()
                 val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
@@ -58,13 +63,14 @@ class HomeMenuViewModel @Inject constructor(
                     val student = students.firstOrNull { it.id == lesson.studentId }
                     student?.let { lesson.calculateFee(it) } ?: 0.0
                 }
-                HomeMenuUiState(
-                    studentCount = students.size,
-                    classCount = classCount,
-                    lessonCount = lessons.size,
-                    weekRevenue = weekTotal,
-                    monthRevenue = monthTotal
-                )
+                    HomeMenuUiState(
+                        studentCount = students.size,
+                        classCount = classCount,
+                        lessonCount = lessons.size,
+                        weekRevenue = weekTotal,
+                        monthRevenue = monthTotal
+                    )
+                }
             }.collect { state ->
                 _uiState.value = state
             }

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -68,21 +68,17 @@ class SettingsViewModel @Inject constructor(
 
     suspend fun exportBackup(): String = backupRepository.exportJson()
 
-    suspend fun restoreBackup(json: String): Boolean {
-        return backupRepository.restoreFromJson(json).isSuccess
-
-      fun restoreBackup(json: String) {
-        viewModelScope.launch {
-            try {
-                backupRepository.restoreFromJson(json)
-            } catch (e: SerializationException) {
-                _errorMessage.value = "Invalid backup data: ${e.message}".trim()
-            } catch (e: SQLiteException) {
-                _errorMessage.value =
-                    "Database error while restoring backup: ${e.message}".trim()
-            }
-        }
+    suspend fun restoreBackup(json: String): Boolean = try {
+        backupRepository.restoreFromJson(json).isSuccess
+    } catch (e: SerializationException) {
+        _errorMessage.value = "Invalid backup data: ${e.message}".trim()
+        false
+    } catch (e: SQLiteException) {
+        _errorMessage.value =
+            "Database error while restoring backup: ${e.message}".trim()
+        false
     }
+
 
     fun dismissError() { _errorMessage.value = null }
 }

--- a/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
@@ -34,6 +34,7 @@ import gr.eduinvoice.domain.student.RestoreStudent
 import gr.eduinvoice.domain.student.SoftDeleteStudent
 import gr.eduinvoice.domain.student.StudentUseCases
 import gr.eduinvoice.domain.student.UpdateStudent
+import gr.eduinvoice.FakeUserProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,6 +57,8 @@ class HomeMenuViewModelTest {
 
     private val studentFlow = MutableStateFlow<List<Student>>(emptyList())
     private val lessonFlow = MutableStateFlow<List<Lesson>>(emptyList())
+
+    private val userProvider = FakeUserProvider(1L)
 
     private val studentDao = FakeStudentDao(studentFlow)
     private val lessonDao = FakeLessonDao(lessonFlow)
@@ -91,7 +94,7 @@ class HomeMenuViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun classCountReflectsDistinctClasses() = runTest {
-        val vm = HomeMenuViewModel(studentUseCases, lessonUseCases)
+        val vm = HomeMenuViewModel(studentUseCases, lessonUseCases, userProvider)
         advanceUntilIdle()
         assertEquals(0, vm.uiState.value.classCount)
 


### PR DESCRIPTION
- inject `CurrentUserProvider` into `HomeMenuViewModel`
- update tests and instrumentation test to provide a `FakeUserProvider`
- repair `SettingsViewModel` braces and remove duplicate overload
- bump version to 0.22.3

`./gradlew clean assemble test lintDebug` fails due to network errors when fetching Robolectric artifacts

------
https://chatgpt.com/codex/tasks/task_e_688a30e94c848330abf33de3fc30ae67