### PR TITLE
feat(agents): add task stub guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,73 @@ From version `0.22.0` onward, changelog entries use the full
 heading and bump `versionName` in `app/build.gradle` only when cutting a
 release (patch/minor/major). The current version is `0.22.0`.
 
+## 9. Guiding Principles for Task Stub Generation
+
+This document provides a set of guiding principles for all agents, including AI assistants like Codex, when creating new task stubs for this project. The goal is to ensure all tasks are thorough, actionable, and verifiable. All generated task stubs **must** adhere to the following principles.
+
+### 1. The Principle of Decomposition
+
+Large features must be broken down into smaller, logical, and atomic task stubs. Avoid creating single, monolithic tasks for complex features. A good task represents a single, verifiable unit of work that can be completed in one pull request.
+
+* **DO:** Create separate tasks for UI layout, business logic, data models, and resource creation.
+* **DON'T:** Create a single task called "Implement Login Screen."
+
+### 2. The Principle of Specificity
+
+Tasks must be unambiguous and provide concrete details. The agent is expected to analyze the existing codebase to provide accurate file paths, class names, and method signatures.
+
+* **DO:** Include specific file paths (e.g., `app/src/main/res/layout/activity_main.xml`).
+* **DO:** Suggest specific component IDs, class names, or method names.
+* **DO:** Include short, illustrative code snippets in XML or Kotlin where appropriate.
+* **DON'T:** Use vague instructions like "update the layout" or "add the logic."
+
+### 3. The Principle of Verifiability
+
+Every task must include a clear set of acceptance criteria. This is a checklist that a developer or QA engineer can use to confirm that the task is 100% complete and correct.
+
+* **DO:** List 2-5 specific, testable outcomes.
+* **DON'T:** Finish a task description without defining what "done" means.
+
+---
+
+### The Golden Standard: Task Stub Template
+
+All generated stubs must follow this Markdown template:
+
+**Task Title:** [A concise, one-line summary of the work]
+
+* **File(s) to Create/Modify:**
+    * `[path/to/file_one.kt]`
+    * `[path/to/file_two.xml]`
+* **Description of Work:**
+    * A detailed, step-by-step explanation of the required changes.
+    * Use bullet points for clarity.
+    * Reference specific IDs, methods, and components.
+    * *Example Snippet (if helpful):*
+        ```kotlin
+        // A short code example
+        ```
+* **Acceptance Criteria:**
+    * [ ] The first condition of "done."
+    * [ ] The second condition of "done."
+    * [ ] The third condition of "done."
+
+### Good Example
+
+**Task Title:** Update Primary Button Style
+
+* **File(s) to Create/Modify:**
+    * `app/src/main/res/values/styles.xml`
+    * `app/src/main/res/layout/fragment_login.xml`
+* **Description of Work:**
+    * In `styles.xml`, create a new style named `AppTheme.Button.Primary`.
+    * This style should set the `backgroundColor` to `@color/colorPrimary` and `textColor` to `@color/white`.
+    * In `fragment_login.xml`, apply this new style to the button with the ID `@+id/login_button`.
+* **Acceptance Criteria:**
+    * [ ] A new button style `AppTheme.Button.Primary` exists in `styles.xml`.
+    * [ ] The login button in the running app now has the new primary color background.
+    * [ ] The login button text is white.
+
 ---
 
 *End of AGENTS.md*


### PR DESCRIPTION
- Added section detailing guiding principles for task stub generation in `AGENTS.md`.
- Provides template and example for consistent task creation.
- Ran `./gradlew clean assemble test lintDebug` (tests failing).


------
https://chatgpt.com/codex/tasks/task_e_688b4a940cd4833094bf180d44ec12c0