### PR TITLE
feat(register): map experience ranges

### DIFF
--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -97,13 +97,50 @@ fun RegisterScreen(
                 label = { Text(stringResource(R.string.subject_specialty)) },
                 modifier = Modifier.fillMaxWidth()
             )
-            OutlinedTextField(
-                value = if (uiState.yearsExperience == 0) "" else uiState.yearsExperience.toString(),
-                onValueChange = viewModel::updateYearsExperience,
-                label = { Text(stringResource(R.string.years_experience)) },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            var expanded by remember { mutableStateOf(false) }
+            val ranges = listOf(
+                stringResource(R.string.years_experience_range_0_5),
+                stringResource(R.string.years_experience_range_6_10),
+                stringResource(R.string.years_experience_range_11_15),
+                stringResource(R.string.years_experience_range_16_20),
+                stringResource(R.string.years_experience_range_20_plus)
             )
+            val currentRange = when (uiState.yearsExperience) {
+                in 0..5 -> stringResource(R.string.years_experience_range_0_5)
+                in 6..10 -> stringResource(R.string.years_experience_range_6_10)
+                in 11..15 -> stringResource(R.string.years_experience_range_11_15)
+                in 16..20 -> stringResource(R.string.years_experience_range_16_20)
+                else -> stringResource(R.string.years_experience_range_20_plus)
+            }
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = !expanded }
+            ) {
+                OutlinedTextField(
+                    readOnly = true,
+                    value = currentRange,
+                    onValueChange = {},
+                    label = { Text(stringResource(R.string.years_experience)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    ranges.forEach { rangeLabel ->
+                        DropdownMenuItem(
+                            text = { Text(rangeLabel) },
+                            onClick = {
+                                expanded = false
+                                viewModel.updateYearsExperience(rangeLabel)
+                            }
+                        )
+                    }
+                }
+            }
             OutlinedTextField(
                 value = uiState.password,
                 onValueChange = viewModel::updatePassword,

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterViewModel.kt
@@ -26,7 +26,7 @@ class RegisterViewModel @Inject constructor(
     fun updateFullName(value: String) { _uiState.value = _uiState.value.copy(fullName = value) }
     fun updateSubjectSpecialty(value: String) { _uiState.value = _uiState.value.copy(subjectSpecialty = value) }
     fun updateYearsExperience(value: String) {
-        val years = value.toIntOrNull() ?: 0
+        val years = Regex("\\d+").find(value)?.value?.toIntOrNull() ?: 0
         _uiState.value = _uiState.value.copy(yearsExperience = years)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,11 @@
     <!-- Registration -->
     <string name="subject_specialty">Subject Specialty</string>
     <string name="years_experience">Years Experience</string>
+    <string name="years_experience_range_0_5">0-5</string>
+    <string name="years_experience_range_6_10">6-10</string>
+    <string name="years_experience_range_11_15">11-15</string>
+    <string name="years_experience_range_16_20">16-20</string>
+    <string name="years_experience_range_20_plus">20+</string>
 
     <!-- Settings categories -->
     <string name="general">General</string>

--- a/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
@@ -61,13 +61,21 @@ class RegisterViewModelTest {
         vm.updatePassword("secret")
         vm.updateFullName("Alice")
         vm.updateSubjectSpecialty("Math")
-        vm.updateYearsExperience("1")
+        vm.updateYearsExperience("0-5")
         var called = false
         vm.register { called = true }
         advanceUntilIdle()
         assertEquals(1L, prefs.loggedInUserId.first())
         assertEquals(true, called)
         assertNull(vm.uiState.value.error)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun updateYearsExperienceParsesRange() = runTest {
+        val vm = RegisterViewModel(useCases, prefs)
+        vm.updateYearsExperience("11-15")
+        assertEquals(11, vm.uiState.value.yearsExperience)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -86,7 +94,7 @@ class RegisterViewModelTest {
         vm.updatePassword("secret")
         vm.updateFullName("Bob")
         vm.updateSubjectSpecialty("Math")
-        vm.updateYearsExperience("2")
+        vm.updateYearsExperience("6-10")
         vm.register {}
         advanceUntilIdle()
         assertNull(prefs.loggedInUserId.first())


### PR DESCRIPTION
- add regex parsing for experience ranges
- replace numeric input with dropdown selection
- provide range strings for localization
- extend RegisterViewModel tests for range parsing

`./gradlew test` *(fails: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688b4ce7fcec833082f2779aa39c106c