### PR TITLE
fix(data): recover database on corruption

### DIFF
--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -6,10 +6,13 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import gr.eduinvoice.data.database.DatabaseConstants
 import gr.eduinvoice.data.database.EduInvoiceDatabase
 import gr.eduinvoice.data.user.UserPreferencesRepository
 import net.sqlcipher.database.SQLiteDatabase
 import kotlinx.coroutines.runBlocking
+import android.database.sqlite.SQLiteException
+import android.util.Log
 import javax.inject.Singleton
 
 @Module
@@ -25,7 +28,13 @@ object DatabaseModule {
         val pass = runBlocking { prefs.getDbPassphrase() }
         require(!pass.isNullOrEmpty()) { "Database passphrase unavailable" }
         val passphrase = SQLiteDatabase.getBytes(pass!!.toCharArray())
-        return EduInvoiceDatabase.getDatabase(context, passphrase)
+        return try {
+            EduInvoiceDatabase.getDatabase(context, passphrase)
+        } catch (e: SQLiteException) {
+            Log.e("DatabaseModule", "Database open failed, attempting recovery", e)
+            context.getDatabasePath(DatabaseConstants.DATABASE_NAME).delete()
+            EduInvoiceDatabase.getDatabase(context, passphrase)
+        }
     }
 
     // DatabaseModule only provides the Room database instance.

--- a/data/src/test/java/gr/eduinvoice/data/DatabaseRecoveryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/DatabaseRecoveryTest.kt
@@ -1,0 +1,47 @@
+package gr.eduinvoice.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.DatabaseConstants
+import gr.eduinvoice.data.di.DatabaseModule
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.junit.Assert.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class DatabaseRecoveryTest {
+    private lateinit var context: Context
+    private lateinit var prefs: UserPreferencesRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        prefs = UserPreferencesRepository(context)
+        runBlocking { prefs.setDbPassphrase("secret") }
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteDatabase(DatabaseConstants.DATABASE_NAME)
+    }
+
+    @Test
+    fun recreatesCorruptDatabaseFile() = runBlocking {
+        val dbFile = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
+        dbFile.parentFile?.mkdirs()
+        dbFile.writeBytes(ByteArray(32) { 1 })
+        val originalSize = dbFile.length()
+
+        val db = DatabaseModule.provideEduInvoiceDatabase(context, prefs)
+        val students = db.studentDao().getAllActiveStudents(0).first()
+        assertTrue(students.isEmpty())
+        assertTrue(dbFile.length() != originalSize)
+        db.close()
+    }
+}


### PR DESCRIPTION
## Summary
- handle SQLiteException when opening the Room db
- log the recovery and recreate the db file
- add regression test for corrupt database recovery

## Testing
- `./gradlew lintDebug`
- `./gradlew test` *(fails: Failed to fetch Maven artifact org.robolectric:android-all-instrumented)*
- `./gradlew assemble` *(fails: network unreachable during dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b660566d08330970828274e8f14ed