### PR TITLE
fix(auth): use resource string for login error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.9] - 2025-08-03
+### Fixed
+- Login error message now uses a string resource and displays with smaller typography.
+
 ## [0.22.8] - 2025-08-02
 ### Added
 - Prompt to enable Autofill when no service is active on login or registration screens.

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginScreen.kt
@@ -104,7 +104,13 @@ fun LoginScreen(
             TextButton(onClick = onResetPassword, modifier = Modifier.align(Alignment.End)) {
                 Text(stringResource(R.string.forgot_password))
             }
-            uiState.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+            uiState.error?.let {
+                Text(
+                    it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
         }
         }
         if (showAutofillDialog) {

--- a/app/src/main/java/gr/eduinvoice/ui/user/LoginViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/LoginViewModel.kt
@@ -1,8 +1,11 @@
 package gr.eduinvoice.ui.user
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import gr.eduinvoice.R
 import gr.eduinvoice.domain.user.UserUseCases
 import gr.eduinvoice.data.user.UserPreferencesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val useCases: UserUseCases,
-    private val prefs: UserPreferencesRepository
+    private val prefs: UserPreferencesRepository,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
@@ -29,7 +33,7 @@ class LoginViewModel @Inject constructor(
                 prefs.setLoggedInUser(user.id)
                 onSuccess(user.id)
             } else {
-                _uiState.value = _uiState.value.copy(error = "Invalid credentials")
+                _uiState.value = _uiState.value.copy(error = context.getString(R.string.error_invalid_password))
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="confirm_password">Confirm Password</string>
     <string name="full_name">Full Name</string>
     <string name="settings">Settings</string>
+    <string name="error_invalid_password">Invalid credentials</string>
 
     <!-- Registration -->
     <string name="subject_specialty">Subject Specialty</string>

--- a/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
@@ -2,6 +2,7 @@ package gr.eduinvoice.ui.user
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.R
 import gr.eduinvoice.MainDispatcherRule
 import gr.eduinvoice.data.dao.UserDao
 import gr.eduinvoice.data.model.User
@@ -53,7 +54,7 @@ class LoginViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun successfulLoginUpdatesPrefs() = runTest {
-        val vm = LoginViewModel(useCases, prefs)
+        val vm = LoginViewModel(useCases, prefs, context)
         vm.updateUsername("bob")
         vm.updatePassword("pass")
         var callbackId: Long? = null
@@ -67,7 +68,7 @@ class LoginViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun failedLoginSetsError() = runTest {
-        val vm = LoginViewModel(useCases, prefs)
+        val vm = LoginViewModel(useCases, prefs, context)
         vm.updateUsername("bob")
         vm.updatePassword("wrong")
         var called = false
@@ -75,6 +76,6 @@ class LoginViewModelTest {
         advanceUntilIdle()
         assertNull(prefs.loggedInUserId.first())
         assertEquals(false, called)
-        assertEquals("Invalid credentials", vm.uiState.value.error)
+        assertEquals(context.getString(R.string.error_invalid_password), vm.uiState.value.error)
     }
 }


### PR DESCRIPTION
- WHAT changed
  - added `error_invalid_password` string
  - LoginViewModel uses this resource via injected context
  - LoginScreen shows errors with `bodySmall` typography
  - updated unit test for new error string
  - documented fix in changelog
- WHY it matters
  - keeps strings centralised and improves UI consistency
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688b6605ea5c833087bc3dbac6a37851