### PR TITLE
feat(resources): add navigation drawer menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.10] - 2025-08-04
+### Added
+- Navigation drawer menu resource for Home, Students, Lessons, Groups and Settings.
 
 ## [0.22.9] - 2025-08-03
 ### Fixed

--- a/app/src/main/res/drawable/ic_groups.xml
+++ b/app/src/main/res/drawable/ic_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7,10a3,3 0 1,0 0,-6 3,3 0 1,0 0,6zm10,0a3,3 0 1,0 0,-6 3,3 0 1,0 0,6zM2,20v-1c0,-2 4,-3 10,-3s10,1 10,3v1H2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lessons.xml
+++ b/app/src/main/res/drawable/ic_lessons.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,4h18v2H3zM3,9h12v2H3zM3,14h18v2H3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_settings.xml
+++ b/app/src/main/res/drawable/ic_settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,8a4,4 0 1,0 0,8 4,4 0 1,0 0,-8zM4,12l1,-2 2,-1 1,-2 2,-1 1,-2h4l1,2 2,1 1,2 2,1 1,2-1,2-2,1-1,2-2,1-1,2h-4l-1,-2-2,-1-1,-2-2,-1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_students.xml
+++ b/app/src/main/res/drawable/ic_students.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,12c2.7,0 5,-2.3 5,-5s-2.3,-5 -5,-5 -5,2.3 -5,5 2.3,5 5,5zM2,20v-1c0,-3 6,-4 10,-4s10,1 10,4v1H2z"/>
+</vector>

--- a/app/src/main/res/menu/menu_drawer.xml
+++ b/app/src/main/res/menu/menu_drawer.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/nav_home"
+        android:icon="@drawable/ic_home"
+        android:title="@string/home" />
+
+    <item
+        android:id="@+id/nav_students"
+        android:icon="@drawable/ic_students"
+        android:title="@string/students" />
+
+    <item
+        android:id="@+id/nav_lessons"
+        android:icon="@drawable/ic_lessons"
+        android:title="@string/lessons" />
+
+    <item
+        android:id="@+id/nav_groups"
+        android:icon="@drawable/ic_groups"
+        android:title="@string/groups" />
+
+    <item
+        android:id="@+id/nav_settings"
+        android:icon="@drawable/ic_settings"
+        android:title="@string/settings" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,5 +124,8 @@
     <string name="backup_restore">Restore Backup</string>
     <string name="backup_restored">Backup restored</string>
     <string name="invalid_backup">Invalid backup file</string>
+    <!-- Navigation drawer -->
+    <string name="home">Home</string>
+    <string name="groups">Groups</string>
     <string name="autofill_setup_message">Enable Autofill in settings to save and fill passwords automatically.</string>
 </resources>


### PR DESCRIPTION
- WHAT changed
  - Added `menu_drawer.xml` menu resource with five navigation items
  - Created placeholder vector icons for each item
  - Added new string resources `home` and `groups`
  - Documented change in `CHANGELOG.md`
- WHY it matters
  - Provides foundation for navigation drawer UI
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_688b7eb5d2f48330b971dcb21ad297ab