### PR TITLE
feat(resources): add navigation drawer header layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.11] - 2025-08-05
+### Added
+- Navigation drawer header layout resource.
+
 ## [0.22.10] - 2025-08-04
 ### Added
 - Navigation drawer menu resource for Home, Students, Lessons, Groups and Settings.

--- a/app/src/main/res/layout/menu_header_layout.xml
+++ b/app/src/main/res/layout/menu_header_layout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="bottom"
+    android:padding="@dimen/spacing_medium">
+
+    <ImageView
+        android:id="@+id/header_image"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_gravity="center_horizontal"
+        android:contentDescription="@string/app_logo_desc"
+        android:src="@drawable/tutorbilling_logo" />
+
+    <TextView
+        android:id="@+id/header_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceTitleLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:text="@string/app_name" />
+
+    <TextView
+        android:id="@+id/header_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:gravity="center"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurface" />
+
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <dimen name="spacing_small">8dp</dimen>
+    <dimen name="spacing_medium">16dp</dimen>
+    <dimen name="spacing_large">24dp</dimen>
+</resources>


### PR DESCRIPTION
- WHAT changed
  - Added `menu_header_layout.xml` with material spacing
  - Introduced `dimens.xml` for common spacing values
  - Documented new resource in CHANGELOG
- WHY it matters
  - Provides header layout for the navigation drawer
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_688b86374c0483308e2cc44dc6522c17