### PR TITLE
feat(ui): add main activity layout with drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.12] - 2025-08-06
+### Added
+- Main activity layout with drawer, toolbar, compose host and navigation view.
+
 ## [0.22.11] - 2025-08-05
 ### Added
 - Navigation drawer header layout resource.

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+    </LinearLayout>
+
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/navigation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        app:menu="@menu/menu_drawer"
+        app:headerLayout="@layout/menu_header_layout" />
+
+</androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
- Added `activity_main.xml` containing `DrawerLayout`, `Toolbar`, `ComposeView` and `NavigationView`.
- Connected navigation view to `menu_drawer.xml` and header layout.
- Documented addition in `CHANGELOG.md`.

To test, run `./gradlew test` (requires Android SDK).

------
https://chatgpt.com/codex/tasks/task_e_688b8b2fce88833091bcc5be6c3710cd