### PR TITLE
feat(resources): add drawer strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.13] - 2025-08-07
+### Added
+- Drawer open/close messages in `strings.xml` and wired up `MainActivity` to use them.
 ## [0.22.12] - 2025-08-06
 ### Added
 - Main activity layout with drawer, toolbar, compose host and navigation view.

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -1,12 +1,15 @@
 package gr.eduinvoice
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.appcompat.widget.Toolbar
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.ui.settings.SettingsViewModel
@@ -14,11 +17,28 @@ import gr.eduinvoice.ui.theme.TutorBillingTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
+        setContentView(R.layout.activity_main)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        val drawerLayout = findViewById<DrawerLayout>(R.id.drawer_layout)
+
+        val toggle = ActionBarDrawerToggle(
+            this,
+            drawerLayout,
+            toolbar,
+            R.string.navigation_drawer_open,
+            R.string.navigation_drawer_close
+        )
+        drawerLayout.addDrawerListener(toggle)
+        toggle.syncState()
+
+        findViewById<ComposeView>(R.id.compose_view).setContent {
             val viewModel: SettingsViewModel = hiltViewModel()
             val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
             TutorBillingTheme(darkTheme = uiState.settings.darkTheme) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,5 +127,7 @@
     <!-- Navigation drawer -->
     <string name="home">Home</string>
     <string name="groups">Groups</string>
+    <string name="navigation_drawer_open">Open navigation drawer</string>
+    <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="autofill_setup_message">Enable Autofill in settings to save and fill passwords automatically.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add navigation drawer open/close strings
- hook up MainActivity with DrawerLayout and toggle

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688ba3c2d1cc83308a98ecb98e5ac296