### PR TITLE
refactor(app): expose navController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.14] - 2025-08-08
+### Changed
+- `TutorBillingApp` now accepts an optional `NavHostController` parameter for easier navigation testing.
+
 ## [0.22.13] - 2025-08-07
 ### Added
 - Vector assets for bottom navigation icons.

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.NavHostController
 import androidx.navigation.navArgument
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.ui.home.HomeMenuScreen
@@ -34,8 +35,9 @@ import gr.eduinvoice.ui.user.SessionViewModel
 import gr.eduinvoice.ui.user.ResetPasswordScreen
 
 @Composable
-fun TutorBillingApp() {
-    val navController = rememberNavController()
+fun TutorBillingApp(
+    navController: NavHostController = rememberNavController(),
+) {
     val sessionViewModel: SessionViewModel = hiltViewModel()
     val loggedIn by sessionViewModel.isLoggedIn.collectAsStateWithLifecycle()
 


### PR DESCRIPTION
## Summary
- pass optional `NavHostController` to `TutorBillingApp`
- note API change in changelog

## Testing
- `./gradlew assemble` *(fails: SDK location missing)*
- `./gradlew test` *(fails: SDK location missing)*
- `./gradlew lintDebug` *(fails: SDK location missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ba95519788330a4005bdf060d9cdb