### PR TITLE
feat(build): add appcompat and drawerlayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.16] - 2025-08-10
+### Build/CI
+- Added `androidx.appcompat` and `androidx.drawerlayout` dependencies.
 ## [0.22.15] - 2025-08-09
 ### Added
 - MainActivity handles navigation drawer item clicks and stores the app's `NavHostController`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,8 @@ android {
         implementation 'androidx.core:core-ktx:1.16.0'
         implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.1'
         implementation 'androidx.activity:activity-compose:1.10.1'
+        implementation 'androidx.appcompat:appcompat:1.6.1'
+        implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
         // Material Components (for XML themes)
         implementation 'com.google.android.material:material:1.12.0'
     // Jetpack Compose


### PR DESCRIPTION
- WHAT changed
  - Added `androidx.appcompat:appcompat:1.6.1` and `androidx.drawerlayout:drawerlayout:1.2.0` to module dependencies
  - Logged new version entry in `CHANGELOG.md`
- WHY it matters
  - MainActivity relies on AppCompat and DrawerLayout classes
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688baf2aa3088330a1af592a715b338e