### PR TITLE
feat(release): prep version 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.23] - 2025-08-11
+### Feature: Navigation Drawer
+- Introduced a sliding drawer with header and menu for quick navigation.
+- Updated MainActivity layout with toolbar and drawer integration.
+- Drawer selections navigate using a stored `NavHostController`.
+- Added open/close string resources and vector assets.
+- Build now includes `appcompat` and `drawerlayout`.
 ## [0.22.16] - 2025-08-10
 ### Build/CI
 - Added `androidx.appcompat` and `androidx.drawerlayout` dependencies.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ EduInvoice is an Android application for managing tutoring sessions and invoices
 - Theme and preference settings via DataStore
 - Backup and restore your data to JSON
 - SQLCipher-encrypted database
+- Sliding navigation drawer for quick navigation between screens
 
 ## Prerequisites
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 20
-        versionName "0.22.8"
+        versionName "0.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
- summarize navigation drawer features since 0.22.10 in CHANGELOG
- bump versionName to 0.23
- mention drawer in README feature list

`./gradlew clean assemble` succeeds, but tests fail due to network access
restrictions; lint passes.


------
https://chatgpt.com/codex/tasks/task_e_688bcac16a6483309800ced90441513d