### PR TITLE
feat(changelog): add analyzer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ The current version is `0.22.0`. Starting with this release, EduInvoice
 follows [Semantic Versioning](https://semver.org) in the form
 `MAJOR.MINOR.PATCH`. Bump the version only when making a new release and
 record changes under the corresponding heading in the changelog.
+Run `python3 scripts/analyze_changelog.py` to verify changelog version headings.

--- a/scripts/analyze_changelog.py
+++ b/scripts/analyze_changelog.py
@@ -1,0 +1,52 @@
+import re
+import sys
+import subprocess
+
+CHANGELOG = 'CHANGELOG.md'
+START_VERSION = '[0.22.0]'
+HEADER_RE = re.compile(r'^## \[\d+\.\d+\.\d+\] -')
+
+def main():
+    try:
+        with open(CHANGELOG, 'r') as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        print(f'Could not find {CHANGELOG}', file=sys.stderr)
+        sys.exit(1)
+
+    start_index = None
+    for i, line in enumerate(lines):
+        if START_VERSION in line:
+            start_index = i
+            break
+    if start_index is None:
+        print(f'Could not locate version {START_VERSION} in {CHANGELOG}', file=sys.stderr)
+        sys.exit(1)
+
+    # Only check headings from the start version up to the most recent release.
+    noncompliant = []
+    for idx, line in enumerate(lines[:start_index + 1], start=1):
+        if line.startswith('## '):
+            if not HEADER_RE.match(line):
+                noncompliant.append((idx, line.strip()))
+
+    if noncompliant:
+        print('Non-compliant changelog headings:')
+        for lineno, text in noncompliant:
+            print(f'{lineno}: {text}')
+        exit_code = 1
+    else:
+        print('All changelog headings from [0.22.0] onward follow MAJOR.MINOR.PATCH.')
+        exit_code = 0
+
+    print('\nLast 5 commits touching CHANGELOG.md:')
+    result = subprocess.run(
+        ['git', 'log', '-n', '5', '--date=short', '--pretty=format:%h %ad %s', '--', CHANGELOG],
+        capture_output=True, text=True
+    )
+    print(result.stdout.strip())
+
+    sys.exit(exit_code)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python script `scripts/analyze_changelog.py` for validating changelog headings
- document running the script in the README

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: java.net.SocketException)*
- `./gradlew lintDebug`
- `python3 scripts/analyze_changelog.py`

------
https://chatgpt.com/codex/tasks/task_e_688bf5456f608330b034a7106caf8074