### PR TITLE
feat(ui): add drawer menu button in compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.2] - 2025-08-13
+### Changed
+- Added hamburger menu button on top-level screens to open the navigation drawer.
+
 ## [0.23.1] - 2025-08-12
 ### Changed
 - Invoice utilities now return operation success and log failures.

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -27,6 +27,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     private lateinit var drawerLayout: DrawerLayout
     private lateinit var navController: NavHostController
 
+    fun openDrawer() {
+        drawerLayout.openDrawer(GravityCompat.START)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -57,7 +61,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    TutorBillingApp(navController)
+                    TutorBillingApp(navController, ::openDrawer)
                 }
             }
         }

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -37,6 +37,7 @@ import gr.eduinvoice.ui.user.ResetPasswordScreen
 @Composable
 fun TutorBillingApp(
     navController: NavHostController = rememberNavController(),
+    openDrawer: () -> Unit = {},
 ) {
     val sessionViewModel: SessionViewModel = hiltViewModel()
     val loggedIn by sessionViewModel.isLoggedIn.collectAsStateWithLifecycle()
@@ -92,6 +93,7 @@ fun TutorBillingApp(
         // Home Screen
         composable(Screen.Home.route) {
             HomeMenuScreen(
+                onOpenDrawer = openDrawer,
                 onNavigateToStudent = { navController.navigate(Screen.Students.route) },
                 onClassesClick = { navController.navigate(Screen.Classes.route) },
                 onNavigateToLesson = { navController.navigate(Screen.Lessons.route) },
@@ -103,11 +105,11 @@ fun TutorBillingApp(
             )
         }
 
-        studentGraph(navController)
+        studentGraph(navController, openDrawer)
 
         composable(Screen.Groups.route) {
             GroupsScreen(
-                onBack = { navController.popBackStack() },
+                openDrawer = openDrawer,
                 onGroupClick = { id -> navController.navigate(Screen.Group.createRoute(id)) },
                 onAddGroup = { navController.navigate(Screen.Group.createRoute(0)) }
             )
@@ -123,7 +125,7 @@ fun TutorBillingApp(
         // Classes list screen
         composable(Screen.Classes.route) {
             ClassesScreen(
-                onBack = { navController.popBackStack() },
+                openDrawer = openDrawer,
                 onStudentClick = { id ->
                     navController.navigate(Screen.Student.createRoute(id))
                 }
@@ -133,7 +135,7 @@ fun TutorBillingApp(
         // Lessons list screen
         composable(Screen.Lessons.route) {
             LessonsScreen(
-                onBack = { navController.popBackStack() },
+                openDrawer = openDrawer,
                 onLessonClick = { studentId, lessonId, groupId ->
                     navController.navigate(
                         Screen.Lesson.createRoute(lessonId, studentId, groupId)
@@ -148,7 +150,7 @@ fun TutorBillingApp(
         // Revenue screen
         composable(Screen.Revenue.route) {
             RevenueScreen(
-                onBack = { navController.popBackStack() },
+                openDrawer = openDrawer,
                 onInvoice = { id -> navController.navigate(Screen.Invoice.createRoute(id)) },
                 onPastInvoices = { navController.navigate(Screen.PastInvoices.route) }
             )
@@ -182,7 +184,7 @@ fun TutorBillingApp(
         // Settings screen
         composable(Screen.Settings.route) {
             SettingsScreen(
-                onBack = { navController.popBackStack() },
+                openDrawer = openDrawer,
                 onPrivacyPolicy = { navController.navigate(Screen.PrivacyPolicy.route) },
                 onLogin = { navController.navigate(Screen.Login.route) },
                 onRegister = { navController.navigate(Screen.Register.route) },

--- a/app/src/main/java/gr/eduinvoice/navigation/StudentNavGraph.kt
+++ b/app/src/main/java/gr/eduinvoice/navigation/StudentNavGraph.kt
@@ -14,17 +14,17 @@ import gr.eduinvoice.ui.student.StudentViewModel
 import gr.eduinvoice.ui.students.StudentsScreen
 import gr.eduinvoice.ui.students.ArchivedStudentsScreen
 
-fun NavGraphBuilder.studentGraph(navController: NavHostController) {
+fun NavGraphBuilder.studentGraph(navController: NavHostController, openDrawer: () -> Unit) {
     navigation(startDestination = Screen.Students.route, route = "student_graph") {
         composable(Screen.Students.route) {
             StudentsScreen(
+                openDrawer = openDrawer,
                 onNavigateToStudent = { id ->
                     navController.navigate(Screen.Student.createRoute(id))
                 },
                 onAddStudent = {
                     navController.navigate(Screen.Student.createRoute(0L))
                 },
-                onBack = { navController.popBackStack() },
                 onViewArchived = { navController.navigate(Screen.ArchivedStudents.route) }
             )
         }

--- a/app/src/main/java/gr/eduinvoice/ui/classes/ClassesScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/classes/ClassesScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
@@ -19,11 +18,12 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gr.eduinvoice.utils.getFullName
+import gr.eduinvoice.ui.design.NavigationMenuButton
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ClassesScreen(
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onStudentClick: (Long) -> Unit,
     viewModel: ClassesViewModel = hiltViewModel()
 ) {
@@ -41,11 +41,7 @@ fun ClassesScreen(
         topBar = {
             AppTopBar(
                 title = "Classes",
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
+                navigationIcon = { NavigationMenuButton(openDrawer) }
             )
         }
     ) { padding ->

--- a/app/src/main/java/gr/eduinvoice/ui/design/NavigationMenuButton.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/design/NavigationMenuButton.kt
@@ -1,0 +1,14 @@
+package gr.eduinvoice.ui.design
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun NavigationMenuButton(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        Icon(Icons.Default.Menu, contentDescription = "Menu")
+    }
+}

--- a/app/src/main/java/gr/eduinvoice/ui/groups/GroupsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/groups/GroupsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
@@ -15,11 +14,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.design.NavigationMenuButton
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GroupsScreen(
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onGroupClick: (Long) -> Unit,
     onAddGroup: () -> Unit,
     viewModel: GroupsViewModel = hiltViewModel()
@@ -30,11 +30,7 @@ fun GroupsScreen(
         topBar = {
             AppTopBar(
                 title = "Groups",
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
+                navigationIcon = { NavigationMenuButton(openDrawer) }
             )
         },
         floatingActionButton = {

--- a/app/src/main/java/gr/eduinvoice/ui/home/HomeMenuScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/home/HomeMenuScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppColors
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.design.AppTopBar
+import gr.eduinvoice.ui.design.NavigationMenuButton
 import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -32,6 +34,7 @@ fun HomeMenuScreen(
     onNavigateToNewLesson: () -> Unit,
     onRevenue: () -> Unit,
     onSettings: () -> Unit,
+    onOpenDrawer: () -> Unit,
     viewModel: HomeMenuViewModel = hiltViewModel()
 ) {
     var showFabMenu by remember { mutableStateOf(false) }
@@ -39,6 +42,12 @@ fun HomeMenuScreen(
 
 
     Scaffold(
+        topBar = {
+            AppTopBar(
+                title = stringResource(R.string.app_name),
+                navigationIcon = { NavigationMenuButton(onOpenDrawer) }
+            )
+        },
         bottomBar = {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/lessons/LessonsScreen.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.design.NavigationMenuButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -29,7 +29,7 @@ import java.time.format.DateTimeFormatter
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LessonsScreen(
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onLessonClick: (Long, Long, Long) -> Unit,
     onAddLesson: () -> Unit,
     onInvoice: (Long?) -> Unit,
@@ -42,11 +42,7 @@ fun LessonsScreen(
         topBar = {
             AppTopBar(
                 title = "Lessons",
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
+                navigationIcon = { NavigationMenuButton(openDrawer) }
             )
         },
         floatingActionButton = {

--- a/app/src/main/java/gr/eduinvoice/ui/revenue/RevenueScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/revenue/RevenueScreen.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppColors
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
 import gr.eduinvoice.ui.design.MetricCard
+import gr.eduinvoice.ui.design.NavigationMenuButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -26,7 +26,7 @@ import gr.eduinvoice.ui.revenue.StudentDebt
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RevenueScreen(
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onInvoice: (Long?) -> Unit,
     onPastInvoices: () -> Unit,
     viewModel: RevenueViewModel = hiltViewModel(),
@@ -40,11 +40,7 @@ fun RevenueScreen(
         topBar = {
             AppTopBar(
                 title = "Revenue",
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
+                navigationIcon = { NavigationMenuButton(openDrawer) }
             )
         }
     ) { padding ->

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsScreen.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppColors
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.design.NavigationMenuButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -28,7 +28,7 @@ import gr.eduinvoice.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onPrivacyPolicy: () -> Unit,
     onLogin: () -> Unit,
     onRegister: () -> Unit,
@@ -84,14 +84,7 @@ fun SettingsScreen(
         topBar = {
             AppTopBar(
                 title = stringResource(R.string.settings),
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.back)
-                        )
-                    }
-                }
+                navigationIcon = { NavigationMenuButton(openDrawer) }
             )
         }
     ) { padding ->

--- a/app/src/main/java/gr/eduinvoice/ui/students/StudentsScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/students/StudentsScreen.kt
@@ -6,12 +6,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material3.*
 import gr.eduinvoice.ui.design.AppTopBar
 import gr.eduinvoice.ui.design.Dimensions
+import gr.eduinvoice.ui.design.NavigationMenuButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -27,7 +27,7 @@ import gr.eduinvoice.ui.components.StudentCard
 fun StudentsScreen(
     onNavigateToStudent: (Long) -> Unit,
     onAddStudent: () -> Unit,
-    onBack: () -> Unit,
+    openDrawer: () -> Unit,
     onViewArchived: () -> Unit,
     viewModel: StudentsViewModel = hiltViewModel()
 ) {
@@ -37,11 +37,7 @@ fun StudentsScreen(
         topBar = {
             AppTopBar(
                 title = stringResource(R.string.students),
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
-                    }
-                },
+                navigationIcon = { NavigationMenuButton(openDrawer) },
                 actions = {
                     IconButton(onClick = onViewArchived) {
                         Icon(Icons.Default.Unarchive, contentDescription = stringResource(R.string.archived_students))

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -93,7 +93,7 @@ class LessonsScreenTest {
         )
         val vm = LessonsViewModel(lessonUseCases, userProvider)
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
+            LessonsScreen(openDrawer = {}, onLessonClick = { _, _, _ -> }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         val header1 = composeRule.onNodeWithTag("header_1").fetchSemanticsNode().positionInRoot.y
@@ -123,7 +123,7 @@ class LessonsScreenTest {
         val vm = LessonsViewModel(lessonUseCases, userProvider)
         var clicked = false
         composeRule.setContent {
-            LessonsScreen(onBack = {}, onLessonClick = { _, _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
+            LessonsScreen(openDrawer = {}, onLessonClick = { _, _, _ -> clicked = true }, onAddLesson = {}, onInvoice = {}, onPastInvoices = {}, viewModel = vm)
         }
         composeRule.waitForIdle()
         composeRule.onNodeWithText("10:00 • 60 min").performClick()


### PR DESCRIPTION
- added `openDrawer` method in MainActivity and passed to `TutorBillingApp`
- introduced `NavigationMenuButton` composable for drawer access
- updated top‑level screens to use menu icon instead of back arrow
- adjusted navigation graph and tests for new parameters

`./gradlew clean assemble test lintDebug` failed due to network issues during unit tests.

------
https://chatgpt.com/codex/tasks/task_e_688cd1fda4088330a6edf4ada04b89f2