### PR TITLE
feat(ui): toggle toolbar on welcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.3] - 2025-08-14
+### Added
+- Toolbar now hides on the Welcome screen and a hamburger button opens the drawer.
+
 ## [0.23.2] - 2025-08-13
 ### Changed
 - Added hamburger menu button on top-level screens to open the navigation drawer.

--- a/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
@@ -104,7 +104,8 @@ class SettingsScreenFlowTest {
                 WelcomeScreen(
                     onSignIn = {},
                     onSignUp = {},
-                    onSettings = { showSettings.value = true }
+                    onSettings = { showSettings.value = true },
+                    onMenuClick = {}
                 )
             }
         }

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.google.android.material.navigation.NavigationView
 import android.view.MenuItem
+import android.view.View
 import gr.eduinvoice.ui.settings.SettingsViewModel
 import gr.eduinvoice.ui.theme.TutorBillingTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -64,6 +65,11 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                     TutorBillingApp(navController, ::openDrawer)
                 }
             }
+        }
+
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            toolbar.visibility =
+                if (destination.route == Screen.Welcome.route) View.GONE else View.VISIBLE
         }
     }
 

--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -53,7 +53,8 @@ fun TutorBillingApp(
             gr.eduinvoice.ui.welcome.WelcomeScreen(
                 onSignIn = { navController.navigate(Screen.Login.route) },
                 onSignUp = { navController.navigate(Screen.Register.route) },
-                onSettings = { navController.navigate(Screen.Settings.route) }
+                onSettings = { navController.navigate(Screen.Settings.route) },
+                onMenuClick = openDrawer
             )
         }
 

--- a/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/welcome/WelcomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,6 +24,7 @@ fun WelcomeScreen(
     onSignIn: () -> Unit,
     onSignUp: () -> Unit,
     onSettings: () -> Unit,
+    onMenuClick: () -> Unit,
 ) {
     Scaffold(
         floatingActionButton = {
@@ -36,14 +38,27 @@ fun WelcomeScreen(
             enter = fadeIn(),
             exit = fadeOut()
         ) {
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(Dimensions.PaddingMedium),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
         ) {
+            IconButton(
+                onClick = onMenuClick,
+                modifier = Modifier.align(Alignment.TopStart),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.tertiary
+                )
+            ) {
+                Icon(Icons.Default.Menu, contentDescription = "Menu")
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(Dimensions.PaddingMedium),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(Dimensions.PaddingMedium)
+            ) {
             Spacer(modifier = Modifier.height(32.dp))
             Image(
                 painter = painterResource(R.drawable.tutorbilling_logo),
@@ -80,4 +95,5 @@ fun WelcomeScreen(
         }
         }
     }
+}
 }


### PR DESCRIPTION
- WHAT changed
  - hide toolbar on Welcome screen via NavController listener
  - added menu button to WelcomeScreen that opens the drawer
  - passed drawer handler through TutorBillingApp
  - updated instrumentation test and changelog
- WHY it matters
  - provides a cleaner first-run experience and drawer access
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688cd80f540083309adfda83b224fcc5