### PR TITLE
fix(app): enforce login on resume

### DIFF
--- a/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
+++ b/app/src/main/java/gr/eduinvoice/TutorBillingApp.kt
@@ -42,6 +42,15 @@ fun TutorBillingApp(
     val sessionViewModel: SessionViewModel = hiltViewModel()
     val loggedIn by sessionViewModel.isLoggedIn.collectAsStateWithLifecycle()
 
+    LaunchedEffect(loggedIn) {
+        val currentRoute = navController.currentBackStackEntry?.destination?.route
+        if (!loggedIn && currentRoute != Screen.Welcome.route) {
+            navController.navigate(Screen.Welcome.route) {
+                popUpTo(0)
+            }
+        }
+    }
+
     val startDestination = if (loggedIn) Screen.Home.route else Screen.Welcome.route
 
     NavHost(


### PR DESCRIPTION
- ensure `TutorBillingApp` redirects to `Welcome` whenever session is not logged in
- added `LaunchedEffect` that clears restored back stack

`./gradlew clean assemble test lintDebug` *(failed: environment lacked Android SDK access)*

------
https://chatgpt.com/codex/tasks/task_e_688cde3a5e3c8330ae61d6abba54493b