### PR TITLE
feat(shared-user): global user state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.5] - 2025-08-16
+### Added
+- SharedUserViewModel exposes logged-in user and login status.
+- Settings and Profile screens now observe this shared state.
+
 ## [0.23.4] - 2025-08-15
 ### Added
 - ViewModel logs student and lesson counts as they load.

--- a/app/src/main/java/gr/eduinvoice/ui/SharedUserViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/SharedUserViewModel.kt
@@ -1,0 +1,39 @@
+package gr.eduinvoice.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import gr.eduinvoice.data.model.User
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import gr.eduinvoice.domain.user.UserUseCases
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class SharedUserViewModel @Inject constructor(
+    private val prefs: UserPreferencesRepository,
+    private val useCases: UserUseCases
+) : ViewModel() {
+    val currentUser: StateFlow<User?> =
+        prefs.loggedInUserId.flatMapLatest { id ->
+            id?.let { useCases.getUserProfile(it) } ?: flowOf(null)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = null
+        )
+
+    val isLoggedIn: StateFlow<Boolean> =
+        currentUser.map { it != null }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = false
+        )
+}

--- a/app/src/main/java/gr/eduinvoice/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/profile/ProfileViewModel.kt
@@ -4,14 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.model.User
-import gr.eduinvoice.data.user.UserPreferencesRepository
 import gr.eduinvoice.domain.user.UserUseCases
+import gr.eduinvoice.ui.SharedUserViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
     private val useCases: UserUseCases,
-    private val prefs: UserPreferencesRepository
+    private val userViewModel: SharedUserViewModel
 ) : ViewModel() {
 
     data class ProfileUiState(
@@ -34,9 +32,7 @@ class ProfileViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            prefs.loggedInUserId.flatMapLatest { id ->
-                id?.let { useCases.getUserProfile(it) } ?: flowOf(null)
-            }.collect { user ->
+            userViewModel.currentUser.collect { user ->
                 _uiState.value = ProfileUiState(
                     user = user,
                     fullName = user?.fullName ?: "",

--- a/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/settings/SettingsViewModel.kt
@@ -7,9 +7,8 @@ import gr.eduinvoice.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import gr.eduinvoice.data.settings.AppSettings
 import gr.eduinvoice.data.settings.SettingsRepository
-import gr.eduinvoice.domain.user.UserUseCases
 import gr.eduinvoice.data.repository.BackupRepository
-import gr.eduinvoice.data.user.UserPreferencesRepository
+import gr.eduinvoice.ui.SharedUserViewModel
 import gr.eduinvoice.data.model.User
 import android.database.sqlite.SQLiteException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -18,8 +17,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -29,8 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val repository: SettingsRepository,
-    private val prefs: UserPreferencesRepository,
-    private val userUseCases: UserUseCases,
+    private val userViewModel: SharedUserViewModel,
     private val backupRepository: BackupRepository
 ) : ViewModel() {
 
@@ -49,16 +45,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 repository.settings,
-                prefs.loggedInUserId.flatMapLatest { id ->
-                    id?.let {
-                        userUseCases.getUserProfile(it).catch { e ->
-                            if (BuildConfig.DEBUG) {
-                                Log.e("SettingsViewModel", "Error fetching user $it", e)
-                            }
-                            emit(null)
-                        }
-                    } ?: flowOf(null)
-                }
+                userViewModel.currentUser
             ) { settings, user ->
                 SettingsUiState(settings, user)
             }.collect { state ->


### PR DESCRIPTION
- Introduced `SharedUserViewModel` exposing current user and login state
- Settings and Profile view models now observe shared user data
- Updated changelog

`./gradlew clean assemble test lintDebug` fails due to Robolectric artifacts requiring network access

------
https://chatgpt.com/codex/tasks/task_e_688d3281649483309aebdd516a93fff2