### PR TITLE
fix(theme): avoid status bar color deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.7] - 2025-08-18
+### Fixed
+- Replaced deprecated status bar color setter with property assignment.
+
 ## [0.23.6] - 2025-08-17
 ### Fixed
 - Settings and Profile viewmodels now derive the logged-in user from

--- a/app/src/main/java/gr/eduinvoice/ui/theme/Theme.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/theme/Theme.kt
@@ -47,7 +47,7 @@ fun TutorBillingTheme(
             val window = (view.context as Activity).window
             val insetsController = WindowCompat.getInsetsController(window, view)
             insetsController.isAppearanceLightStatusBars = !darkTheme
-            window.setStatusBarColor(colorScheme.primary.toArgb())
+            window.statusBarColor = colorScheme.primary.toArgb()
         }
     }
 


### PR DESCRIPTION
- WHAT changed
  - replaced deprecated `setStatusBarColor` call with `statusBarColor` property
  - documented change in CHANGELOG under version 0.23.7
- WHY it matters
  - resolves API deprecation warning while preserving status bar behavior
- HOW to test (`./gradlew test`)

------
https://chatgpt.com/codex/tasks/task_e_688d4ba68fe08330bba777d30f446747