### PR TITLE
fix(register): specify dropdown menu anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.7] - 2025-08-18
+### Changed
+- Register screen now specifies `MenuAnchorType.PrimaryNotEditable` for the
+  years-of-experience dropdown.
+
 ## [0.23.6] - 2025-08-17
 ### Fixed
 - Settings and Profile viewmodels now derive the logged-in user from

--- a/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
+++ b/app/src/main/java/gr/eduinvoice/ui/user/RegisterScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
@@ -139,7 +140,7 @@ fun RegisterScreen(
                         label = { Text(stringResource(R.string.years_experience)) },
                         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
                         modifier = Modifier
-                            .menuAnchor()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
                             .fillMaxWidth()
                     )
                     ExposedDropdownMenu(


### PR DESCRIPTION
- replaced deprecated `menuAnchor()` usage in Register screen
- updated changelog

Failing tests noted during `./gradlew test`; lint and assemble succeed.

------
https://chatgpt.com/codex/tasks/task_e_688d4ba5ddd08330b5c1c232e32c2fb8