### PR TITLE
feat(database): migrate legacy plaintext DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.7] - 2025-08-18
+### Added
+- Plaintext database files are automatically migrated into the new encrypted format.
+
 ## [0.23.6] - 2025-08-17
 ### Fixed
 - Settings and Profile viewmodels now derive the logged-in user from

--- a/data/src/main/java/gr/eduinvoice/data/database/LegacyMigration.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/LegacyMigration.kt
@@ -1,0 +1,37 @@
+package gr.eduinvoice.data.database
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
+import androidx.room.Room
+import gr.eduinvoice.data.repository.BackupRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+object LegacyMigration {
+    fun migrateIfNeeded(context: Context): String? {
+        val file = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
+        if (!file.exists()) return null
+        return try {
+            SQLiteDatabase.openDatabase(
+                file.path,
+                null,
+                SQLiteDatabase.OPEN_READONLY
+            ).use { }
+            val db = Room.databaseBuilder(
+                context,
+                EduInvoiceDatabase::class.java,
+                DatabaseConstants.DATABASE_NAME
+            )
+                .fallbackToDestructiveMigration(false)
+                .addMigrations(MIGRATION_12_13)
+                .build()
+            val repo = BackupRepository(db)
+            val json = runBlocking(Dispatchers.IO) { repo.exportJson() }
+            db.close()
+            json
+        } catch (_: SQLiteException) {
+            null
+        }
+    }
+}

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -8,6 +8,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import gr.eduinvoice.data.database.DatabaseConstants
 import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.database.LegacyMigration
+import gr.eduinvoice.data.repository.BackupRepository
 import gr.eduinvoice.data.user.UserPreferencesRepository
 import net.sqlcipher.database.SQLiteDatabase
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +39,7 @@ object DatabaseModule {
         } catch (e: SQLiteException) {
             Log.e("DatabaseModule", "Database open failed, attempting recovery", e)
             val dbFile = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
+            val legacyJson = LegacyMigration.migrateIfNeeded(context)
             val deleted = dbFile.delete()
             if (!deleted) {
                 Log.e("DatabaseModule", "Failed to delete corrupt DB at ${dbFile.absolutePath}")
@@ -44,6 +47,10 @@ object DatabaseModule {
             }
             val db = EduInvoiceDatabase.getDatabase(context, passphrase)
             db.openHelper.writableDatabase
+            legacyJson?.let {
+                val repo = BackupRepository(db)
+                runBlocking(Dispatchers.IO) { repo.restoreFromJson(it) }
+            }
             db
         }
     }

--- a/data/src/test/java/gr/eduinvoice/data/LegacyMigrationTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/LegacyMigrationTest.kt
@@ -1,0 +1,59 @@
+package gr.eduinvoice.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import gr.eduinvoice.data.database.DatabaseConstants
+import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.database.MIGRATION_12_13
+import gr.eduinvoice.data.di.DatabaseModule
+import gr.eduinvoice.data.model.Student
+import gr.eduinvoice.data.user.UserPreferencesRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LegacyMigrationTest {
+    private lateinit var context: Context
+    private lateinit var prefs: UserPreferencesRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        prefs = UserPreferencesRepository(context)
+        runBlocking { prefs.setDbPassphrase("secret") }
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteDatabase(DatabaseConstants.DATABASE_NAME)
+    }
+
+    @Test
+    fun migratesPlainDatabase() = runBlocking {
+        val plainDb = Room.databaseBuilder(
+            context,
+            EduInvoiceDatabase::class.java,
+            DatabaseConstants.DATABASE_NAME
+        )
+            .fallbackToDestructiveMigration(false)
+            .addMigrations(MIGRATION_12_13)
+            .build()
+        plainDb.studentDao().insert(
+            Student(name = "Legacy", surname = "", parentMobile = "", className = "A", rate = 10.0)
+        )
+        plainDb.close()
+
+        val db = DatabaseModule.provideEduInvoiceDatabase(context, prefs)
+        val students = db.studentDao().getAllActiveStudents(0).first()
+        assertEquals(1, students.size)
+        assertEquals("Legacy", students.first().name)
+        db.close()
+    }
+}


### PR DESCRIPTION
- WHAT changed
  - added `LegacyMigration` to export plaintext SQLite DB to JSON
  - `DatabaseModule` now attempts this migration on open failure
  - new unit test verifies plaintext DB import
  - changelog updated
- WHY it matters
  - allows automatic upgrade from older unencrypted installs
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688d4bc0943483309478c91e74742abb