### PR TITLE
fix(database): handle init failure gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.8] - 2025-08-19
+### Fixed
+- Startup shows an error dialog guiding the user to Settings → Restore Backup when the database fails to open.
+
 ## [0.23.7] - 2025-08-18
 ### Added
 - Plaintext database files are automatically migrated into the new encrypted format.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 20
-        versionName "0.23"
+        versionCode 21
+        versionName "0.23.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey ?: ''}\""
     }

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -1,8 +1,9 @@
 package gr.eduinvoice
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -18,6 +19,7 @@ import androidx.navigation.compose.rememberNavController
 import com.google.android.material.navigation.NavigationView
 import android.view.MenuItem
 import android.view.View
+import gr.eduinvoice.data.database.DatabaseInitException
 import gr.eduinvoice.ui.settings.SettingsViewModel
 import gr.eduinvoice.ui.theme.TutorBillingTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,42 +37,55 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        try {
+            val toolbar = findViewById<Toolbar>(R.id.toolbar)
+            setSupportActionBar(toolbar)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        setSupportActionBar(toolbar)
+            drawerLayout = findViewById(R.id.drawer_layout)
 
-        drawerLayout = findViewById(R.id.drawer_layout)
+            val toggle = ActionBarDrawerToggle(
+                this,
+                drawerLayout,
+                toolbar,
+                R.string.navigation_drawer_open,
+                R.string.navigation_drawer_close
+            )
+            drawerLayout.addDrawerListener(toggle)
+            toggle.syncState()
 
-        val toggle = ActionBarDrawerToggle(
-            this,
-            drawerLayout,
-            toolbar,
-            R.string.navigation_drawer_open,
-            R.string.navigation_drawer_close
-        )
-        drawerLayout.addDrawerListener(toggle)
-        toggle.syncState()
+            findViewById<NavigationView>(R.id.navigation_view)
+                .setNavigationItemSelectedListener(this)
 
-        findViewById<NavigationView>(R.id.navigation_view).setNavigationItemSelectedListener(this)
-
-        findViewById<ComposeView>(R.id.compose_view).setContent {
-            val viewModel: SettingsViewModel = hiltViewModel()
-            val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-            TutorBillingTheme(darkTheme = uiState.settings.darkTheme) {
-                navController = rememberNavController()
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    TutorBillingApp(navController, ::openDrawer)
+            findViewById<ComposeView>(R.id.compose_view).setContent {
+                val viewModel: SettingsViewModel = hiltViewModel()
+                val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+                TutorBillingTheme(darkTheme = uiState.settings.darkTheme) {
+                    navController = rememberNavController()
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = MaterialTheme.colorScheme.background
+                    ) {
+                        TutorBillingApp(navController, ::openDrawer)
+                    }
                 }
             }
-        }
 
-        navController.addOnDestinationChangedListener { _, destination, _ ->
-            toolbar.visibility =
-                if (destination.route == Screen.Welcome.route) View.GONE else View.VISIBLE
+            navController.addOnDestinationChangedListener { _, destination, _ ->
+                toolbar.visibility =
+                    if (destination.route == Screen.Welcome.route) View.GONE else View.VISIBLE
+            }
+        } catch (e: DatabaseInitException) {
+            showDatabaseErrorDialog()
         }
+    }
+
+    private fun showDatabaseErrorDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.db_init_error_title)
+            .setMessage(R.string.db_init_error_message)
+            .setPositiveButton(R.string.ok) { _, _ -> finish() }
+            .setOnDismissListener { finish() }
+            .show()
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,8 @@
     <string name="backup_restore">Restore Backup</string>
     <string name="backup_restored">Backup restored</string>
     <string name="invalid_backup">Invalid backup file</string>
+    <string name="db_init_error_title">Database Error</string>
+    <string name="db_init_error_message">The database could not be opened. Please restore from backup via Settings → Restore Backup.</string>
     <!-- Navigation drawer -->
     <string name="home">Home</string>
     <string name="groups">Groups</string>

--- a/data/src/main/java/gr/eduinvoice/data/database/DatabaseInitException.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/DatabaseInitException.kt
@@ -1,0 +1,3 @@
+package gr.eduinvoice.data.database
+
+class DatabaseInitException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import gr.eduinvoice.data.database.DatabaseConstants
+import gr.eduinvoice.data.database.DatabaseInitException
 import gr.eduinvoice.data.database.EduInvoiceDatabase
 import gr.eduinvoice.data.database.LegacyMigration
 import gr.eduinvoice.data.repository.BackupRepository
@@ -39,19 +40,26 @@ object DatabaseModule {
         } catch (e: SQLiteException) {
             Log.e("DatabaseModule", "Database open failed, attempting recovery", e)
             val dbFile = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
-            val legacyJson = LegacyMigration.migrateIfNeeded(context)
-            val deleted = dbFile.delete()
-            if (!deleted) {
-                Log.e("DatabaseModule", "Failed to delete corrupt DB at ${dbFile.absolutePath}")
-                throw IllegalStateException("Unable to delete corrupt database")
+            return try {
+                val legacyJson = LegacyMigration.migrateIfNeeded(context)
+                if (!dbFile.delete()) {
+                    Log.e(
+                        "DatabaseModule",
+                        "Failed to delete corrupt DB at ${dbFile.absolutePath}"
+                    )
+                    throw DatabaseInitException("Unable to delete corrupt database", e)
+                }
+                val db = EduInvoiceDatabase.getDatabase(context, passphrase)
+                db.openHelper.writableDatabase
+                legacyJson?.let {
+                    val repo = BackupRepository(db)
+                    runBlocking(Dispatchers.IO) { repo.restoreFromJson(it) }
+                }
+                db
+            } catch (recovery: Exception) {
+                Log.e("DatabaseModule", "Database recovery failed", recovery)
+                throw DatabaseInitException("Database recovery failed", recovery)
             }
-            val db = EduInvoiceDatabase.getDatabase(context, passphrase)
-            db.openHelper.writableDatabase
-            legacyJson?.let {
-                val repo = BackupRepository(db)
-                runBlocking(Dispatchers.IO) { repo.restoreFromJson(it) }
-            }
-            db
         }
     }
 


### PR DESCRIPTION
## Summary
- throw `DatabaseInitException` when database recovery fails and intercept in `MainActivity`
- show dialog guiding users to restore a backup instead of crashing
- bump version to 0.23.8

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688db493506483308336eb2196061721