### PR TITLE
docs: document automatic DB migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.8] - 2025-08-19
+### Added
+- Legacy plaintext databases are automatically converted to SQLCipher on first launch with a fallback export dialog if migration fails.
+
 ## [0.23.7] - 2025-08-18
 ### Added
 - Plaintext database files are automatically migrated into the new encrypted format.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ EduInvoice is an Android application for managing tutoring sessions and invoices
 - Monitor revenue and past invoices
 - Theme and preference settings via DataStore
 - Backup and restore your data to JSON
-- SQLCipher-encrypted database
+- SQLCipher-encrypted database with automatic migration from legacy plaintext
 - Sliding navigation drawer for quick navigation between screens
 
 ## Prerequisites
@@ -59,7 +59,7 @@ in isolation:
 
 ## Backup & Migration
 
-Use the Settings screen to export your entire database to a JSON file and restore it later. When upgrading from versions prior to 0.21.9, create a backup first and restore it after updating so the new SQLCipher encrypted database is populated.
+Use the Settings screen to export your entire database to a JSON file and restore it later. From version `0.23` onward the app automatically converts any legacy plaintext database to SQLCipher on first launch. If the migration fails, a dialog prompts you to export the original database to JSON so it can be restored after reinstalling.
 
 ## Database migrations
 


### PR DESCRIPTION
## Summary
- mention auto migration to SQLCipher in README
- log auto-migration feature with fallback dialog in CHANGELOG

## Testing
- `./gradlew clean`
- `./gradlew assemble` *(fails: Directory does not exist for Android SDK)*
- `./gradlew test` *(fails: No SDK directory)*
- `./gradlew lintDebug` *(fails: No SDK directory)*

------
https://chatgpt.com/codex/tasks/task_e_688db49409648330ad31de4e7a561e63