### PR TITLE
fix(domain): specify user id in archive test

### DIFF
--- a/domain/src/test/java/gr/eduinvoice/domain/student/ArchiveRestoreStudentTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/student/ArchiveRestoreStudentTest.kt
@@ -41,7 +41,7 @@ class ArchiveRestoreStudentTest {
         val archive = SoftDeleteStudent(repository)
         val restore = RestoreStudent(repository)
         val id = insert(Student(name = "Bob", surname = "", parentMobile = "", className = "B", rate = 15.0))
-        archive(id)
+        archive(id, 0)
         val archived = db.studentDao().getArchivedStudents(0).first()
         assertEquals(1, archived.size)
         restore(id)


### PR DESCRIPTION
- WHAT changed
  - pass explicit user id to `SoftDeleteStudent` in `ArchiveRestoreStudentTest`
- WHY it matters
  - ensures test reflects updated `SoftDeleteStudent` signature requiring a user id
- HOW to test (`./gradlew test`)


------
https://chatgpt.com/codex/tasks/task_e_688dce41b9d4833091cffa387f17e0b9