### PR TITLE
fix(test): update LessonDao delete stub

### DIFF
--- a/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
@@ -65,7 +65,7 @@ class InvoiceScreenTest {
             override suspend fun insert(lesson: Lesson): Long = 1L
             override suspend fun update(lesson: Lesson) {}
             override suspend fun delete(lesson: Lesson) {}
-            override suspend fun deleteById(lessonId: Long) {}
+            override suspend fun deleteById(lessonId: Long, userId: Long) {}
             override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flowOf(null)
             override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = flowOf(emptyList())
             override fun getAllLessons(userId: Long): Flow<List<Lesson>> = flowOf(emptyList())


### PR DESCRIPTION
## Summary
- update InvoiceScreenTest LessonDao stub so deleteById takes lessonId and userId

## Testing
- `./gradlew clean`
- `./gradlew assembleDebugAndroidTest` *(fails: No value passed for parameter 'context' in SettingsScreenFlowTest.kt; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688dce41ca808330b6ce7fd8358ca583