### PR TITLE
fix(tests): update login screen instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.9] - 2025-08-20
+### Fixed
+- Login screen test now includes password reset use case and context dependency.
+
 ## [0.23.8] - 2025-08-19
 ### Added
 - Legacy plaintext databases are automatically converted to SQLCipher on first launch with a fallback export dialog if migration fails.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 21
-        versionName "0.23.8"
+        versionCode 22
+        versionName "0.23.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey ?: ''}\""
     }

--- a/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
@@ -8,11 +8,13 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import gr.eduinvoice.data.dao.*
 import gr.eduinvoice.data.database.EduInvoiceDatabase
+import gr.eduinvoice.data.database.LessonWithStudent
 import gr.eduinvoice.data.model.*
 import gr.eduinvoice.data.repository.*
 import gr.eduinvoice.data.settings.SettingsRepository
@@ -80,7 +82,7 @@ class SettingsScreenFlowTest {
             .allowMainThreadQueries()
             .build()
         backupRepo = BackupRepository(db)
-        loginViewModel = LoginViewModel(userUseCases, prefs)
+        loginViewModel = LoginViewModel(userUseCases, prefs, context)
         runBlocking { prefs.setLoggedInUser(null) }
     }
 
@@ -91,7 +93,7 @@ class SettingsScreenFlowTest {
             val showSettings = remember { mutableStateOf(false) }
             if (showSettings.value) {
                 SettingsScreen(
-                    onBack = { showSettings.value = false },
+                    openDrawer = { showSettings.value = false },
                     onPrivacyPolicy = {},
                     onLogin = {},
                     onRegister = {},
@@ -168,22 +170,23 @@ class SettingsScreenFlowTest {
             override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {}
             override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {}
             override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> = flowOf(null)
-            override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+            override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> =
+                flowOf(emptyList<LessonWithStudent>())
             override fun getLessonsWithStudentsByStudent(
                 studentId: Long,
                 userId: Long
-            ): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+            ): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
             override fun getLessonsWithStudentsInDateRange(
                 startDate: String,
                 endDate: String,
                 userId: Long
-            ): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+            ): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
             override fun getLessonsWithStudentsByStudentAndDateRange(
                 studentId: Long,
                 startDate: String,
                 endDate: String,
                 userId: Long
-            ): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+            ): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
         }
         val groupDao = object : GroupDao {
             override suspend fun insertGroup(group: StudentGroup) = 1L
@@ -229,7 +232,7 @@ class SettingsScreenFlowTest {
             val showSettings = remember { mutableStateOf(false) }
             if (showSettings.value) {
                 SettingsScreen(
-                    onBack = { showSettings.value = false },
+                    openDrawer = { showSettings.value = false },
                     onPrivacyPolicy = {},
                     onLogin = {},
                     onRegister = {},
@@ -248,6 +251,7 @@ class SettingsScreenFlowTest {
                     onNavigateToNewLesson = {},
                     onRevenue = {},
                     onSettings = { showSettings.value = true },
+                    onOpenDrawer = {},
                     viewModel = homeVm
                 )
             }
@@ -265,7 +269,7 @@ class SettingsScreenFlowTest {
             val screen = remember { mutableStateOf("login") }
             if (screen.value == "settings") {
                 SettingsScreen(
-                    onBack = { screen.value = "login" },
+                    openDrawer = { screen.value = "login" },
                     onPrivacyPolicy = {},
                     onLogin = {},
                     onRegister = {},

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -16,6 +16,7 @@ import gr.eduinvoice.data.model.GroupStudentCrossRef
 import gr.eduinvoice.data.repository.GroupRepository
 import gr.eduinvoice.data.repository.StudentRepository
 import gr.eduinvoice.data.repository.TutorBillingRepository
+import gr.eduinvoice.data.database.LessonWithStudent
 import gr.eduinvoice.domain.group.*
 import gr.eduinvoice.domain.lesson.*
 import gr.eduinvoice.domain.student.*
@@ -60,7 +61,7 @@ class StudentScreenTest {
             override suspend fun insert(lesson: Lesson): Long = 1L
             override suspend fun update(lesson: Lesson) {}
             override suspend fun delete(lesson: Lesson) {}
-            override suspend fun deleteById(lessonId: Long) {}
+            override suspend fun deleteById(lessonId: Long, userId: Long) {}
             override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flowOf(null)
             override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = lessonFlow.asStateFlow()
             override fun getAllLessons(userId: Long): Flow<List<Lesson>> = lessonFlow.asStateFlow()
@@ -71,10 +72,10 @@ class StudentScreenTest {
             override suspend fun updatePaidStatus(ids: List<Long>, paid: Boolean) {}
             override suspend fun updateInvoicedStatus(ids: List<Long>, invoiced: Boolean) {}
             override fun isLessonInvoiced(lessonId: Long, userId: Long): Flow<Boolean?> = flowOf(null)
-            override fun getLessonsWithStudents(userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
-            override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
-            override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
-            override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
+            override fun getLessonsWithStudents(userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
+            override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
+            override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
+            override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
         }
         val groupDao = object : GroupDao {
             override suspend fun insertGroup(group: StudentGroup): Long = 1L

--- a/app/src/androidTest/java/gr/eduinvoice/ui/user/LoginScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/user/LoginScreenTest.kt
@@ -48,11 +48,12 @@ class LoginScreenTest {
             createUser = CreateUser(repo),
             authenticateUser = AuthenticateUser(repo),
             getUserProfile = GetUserProfile(repo),
-            updateUser = UpdateUser(repo)
+            updateUser = UpdateUser(repo),
+            resetPassword = ResetPassword(repo)
         )
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val prefs = UserPreferencesRepository(context)
-        viewModel = LoginViewModel(useCases, prefs)
+        viewModel = LoginViewModel(useCases, prefs, context)
     }
 
     @Test
@@ -62,7 +63,7 @@ class LoginScreenTest {
             LoginScreen(
                 onBack = {},
                 onLoggedIn = { loggedIn = true },
-                onRegister = {},
+                onResetPassword = {},
                 onSettings = {},
                 viewModel = viewModel
             )


### PR DESCRIPTION
## Summary
- include password reset use case and context when building LoginViewModel in tests
- update settings and student instrumentation tests for new openDrawer and DAO signatures
- bump app version to 0.23.9

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew lintDebug`
- `./gradlew assembleDebugAndroidTest`


------
https://chatgpt.com/codex/tasks/task_e_688dd42da7148330a512eb67c646d7bb