### PR TITLE
fix(student): include userId in test lesson dao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.9] - 2025-08-20
+### Fixed
+- Updated StudentScreenTest fake `LessonDao` to include `userId` in `deleteById`.
+
 ## [0.23.8] - 2025-08-19
 ### Added
 - Legacy plaintext databases are automatically converted to SQLCipher on first launch with a fallback export dialog if migration fails.

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -60,7 +60,7 @@ class StudentScreenTest {
             override suspend fun insert(lesson: Lesson): Long = 1L
             override suspend fun update(lesson: Lesson) {}
             override suspend fun delete(lesson: Lesson) {}
-            override suspend fun deleteById(lessonId: Long) {}
+            override suspend fun deleteById(lessonId: Long, userId: Long) {}
             override fun getLessonById(lessonId: Long, userId: Long): Flow<Lesson?> = flowOf(null)
             override fun getLessonsByStudentId(studentId: Long, userId: Long): Flow<List<Lesson>> = lessonFlow.asStateFlow()
             override fun getAllLessons(userId: Long): Flow<List<Lesson>> = lessonFlow.asStateFlow()


### PR DESCRIPTION
## Summary
- adjust StudentScreenTest's fake LessonDao to match updated deleteById signature requiring userId
- document the change in CHANGELOG

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew lintDebug`
- `./gradlew assembleDebugAndroidTest` *(fails: compilation errors in SettingsScreenFlowTest/LoginScreenTest)*

------
https://chatgpt.com/codex/tasks/task_e_688dd42d12f88330b7368d60e5f49b0d