### PR TITLE
fix(main): initialize navController before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.10] - 2025-08-02
+### Fixed
+- Initialize `navController` before usage to avoid startup crash and handle toolbar visibility within `LaunchedEffect`.
+
 ## [0.23.9] - 2025-08-02
 ### Fixed
 - Updated StudentScreenTest fake `LessonDao` to include `userId` in `deleteById`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 22
-        versionName "0.23.9"
+        versionName "0.23.10"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey ?: ''}\""
     }

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.GravityCompat
@@ -57,10 +58,20 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                 .setNavigationItemSelectedListener(this)
 
             findViewById<ComposeView>(R.id.compose_view).setContent {
+                navController = rememberNavController()
                 val viewModel: SettingsViewModel = hiltViewModel()
                 val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
                 TutorBillingTheme(darkTheme = uiState.settings.darkTheme) {
-                    navController = rememberNavController()
+                    LaunchedEffect(navController) {
+                        navController.addOnDestinationChangedListener { _, destination, _ ->
+                            toolbar.visibility =
+                                if (destination.route == Screen.Welcome.route) {
+                                    View.GONE
+                                } else {
+                                    View.VISIBLE
+                                }
+                        }
+                    }
                     Surface(
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
@@ -68,11 +79,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                         TutorBillingApp(navController, ::openDrawer)
                     }
                 }
-            }
-
-            navController.addOnDestinationChangedListener { _, destination, _ ->
-                toolbar.visibility =
-                    if (destination.route == Screen.Welcome.route) View.GONE else View.VISIBLE
             }
         } catch (e: DatabaseInitException) {
             showDatabaseErrorDialog()


### PR DESCRIPTION
## Summary
- initialize `navController` before use and defer destination listener registration to `LaunchedEffect`
- bump versionName to 0.23.10 and document fix in changelog

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e0744ead48330990e713d2a7c5d49