### PR TITLE
fix(database): validate SQLCipher passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.10] - 2025-08-02
+### Fixed
+- Logged database passphrase length and ensured SQLCipher libraries load before Room initialization.
+- Added defensive passphrase validation during database access.
+
 ## [0.23.9] - 2025-08-02
 ### Fixed
 - Updated StudentScreenTest fake `LessonDao` to include `userId` in `deleteById`.

--- a/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
@@ -1,21 +1,22 @@
 package gr.eduinvoice.data.database
 
 import android.content.Context
+import android.util.Log
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import net.sqlcipher.database.SupportFactory
 import gr.eduinvoice.data.dao.GroupDao
 import gr.eduinvoice.data.dao.LessonDao
 import gr.eduinvoice.data.dao.StudentDao
 import gr.eduinvoice.data.dao.UserDao
+import gr.eduinvoice.data.database.MIGRATION_12_13
 import gr.eduinvoice.data.model.GroupStudentCrossRef
 import gr.eduinvoice.data.model.Lesson
 import gr.eduinvoice.data.model.Student
 import gr.eduinvoice.data.model.StudentGroup
 import gr.eduinvoice.data.model.User
-import gr.eduinvoice.data.database.MIGRATION_12_13
+import net.sqlcipher.database.SupportFactory
 
 @Database(
     entities = [Student::class, Lesson::class, StudentGroup::class, GroupStudentCrossRef::class, User::class],
@@ -39,6 +40,8 @@ abstract class EduInvoiceDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
     companion object {
+        private const val TAG = "EduInvoiceDatabase"
+
         @Volatile
         private var INSTANCE: EduInvoiceDatabase? = null
 
@@ -46,6 +49,11 @@ abstract class EduInvoiceDatabase : RoomDatabase() {
             context: Context,
             passphrase: ByteArray
         ): EduInvoiceDatabase {
+            if (passphrase.isEmpty() || passphrase.all { it == 0.toByte() }) {
+                Log.e(TAG, "Invalid database passphrase; length=${'$'}{passphrase.size}")
+                throw IllegalArgumentException("Invalid database passphrase")
+            }
+            Log.d(TAG, "Using passphrase length ${'$'}{passphrase.size}")
             return INSTANCE ?: synchronized(this) {
                 val factory = SupportFactory(passphrase)
                 val instance = Room.databaseBuilder(

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -1,6 +1,8 @@
 package gr.eduinvoice.data.di
 
 import android.content.Context
+import android.database.sqlite.SQLiteException
+import android.util.Log
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,11 +14,9 @@ import gr.eduinvoice.data.database.EduInvoiceDatabase
 import gr.eduinvoice.data.database.LegacyMigration
 import gr.eduinvoice.data.repository.BackupRepository
 import gr.eduinvoice.data.user.UserPreferencesRepository
-import net.sqlcipher.database.SQLiteDatabase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import android.database.sqlite.SQLiteException
-import android.util.Log
+import net.sqlcipher.database.SQLiteDatabase
 import javax.inject.Singleton
 
 @Module
@@ -31,25 +31,27 @@ object DatabaseModule {
     ): EduInvoiceDatabase {
         val pass = runBlocking(Dispatchers.IO) { prefs.getDbPassphrase() }
         require(pass.isNotEmpty()) { "Database passphrase unavailable" }
+        SQLiteDatabase.loadLibs(context)
         val passphrase = SQLiteDatabase.getBytes(pass.toCharArray())
-        return try {
-            val db = EduInvoiceDatabase.getDatabase(context, passphrase)
+        Log.d("DatabaseModule", "Passphrase length: ${'$'}{passphrase.size}")
+        val db = try {
+            val db = EduInvoiceDatabase.getDatabase(context, passphrase.copyOf())
             // Force open to catch corruption immediately
             db.openHelper.writableDatabase
             db
         } catch (e: SQLiteException) {
             Log.e("DatabaseModule", "Database open failed, attempting recovery", e)
             val dbFile = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
-            return try {
+            try {
                 val legacyJson = LegacyMigration.migrateIfNeeded(context)
                 if (!dbFile.delete()) {
                     Log.e(
                         "DatabaseModule",
-                        "Failed to delete corrupt DB at ${dbFile.absolutePath}"
+                        "Failed to delete corrupt DB at ${'$'}{dbFile.absolutePath}"
                     )
                     throw DatabaseInitException("Unable to delete corrupt database", e)
                 }
-                val db = EduInvoiceDatabase.getDatabase(context, passphrase)
+                val db = EduInvoiceDatabase.getDatabase(context, passphrase.copyOf())
                 db.openHelper.writableDatabase
                 legacyJson?.let {
                     val repo = BackupRepository(db)
@@ -60,7 +62,10 @@ object DatabaseModule {
                 Log.e("DatabaseModule", "Database recovery failed", recovery)
                 throw DatabaseInitException("Database recovery failed", recovery)
             }
+        } finally {
+            passphrase.fill(0)
         }
+        return db
     }
 
     // DatabaseModule only provides the Room database instance.


### PR DESCRIPTION
## Summary
- log SQLCipher passphrase length and load native libs before DB init
- guard against empty or zeroed passphrases when obtaining Room database
- record change in changelog

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: Failed to fetch Robolectric artifact – Network is unreachable)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e075c4e2083308f58afde0c04b621