### PR TITLE
fix(build): expose Firebase API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.11] - 2025-08-02
+### Fixed
+- Google services config updated and BuildConfig now exposes the Firebase API key.
+
 ## [0.23.10] - 2025-08-02
 ### Fixed
 - Logged database passphrase length and ensured SQLCipher libraries load before Room initialization.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -8,7 +10,15 @@ plugins {
     id 'com.google.firebase.crashlytics'
 }
 
-def firebaseKey = findProperty('FIREBASE_API_KEY') ?: System.getenv('FIREBASE_API_KEY')
+def firebaseKey = ""
+def googleServicesFile = file("google-services.json")
+if (googleServicesFile.exists()) {
+    def json = new JsonSlurper().parse(googleServicesFile)
+    firebaseKey = json.client?.getAt(0)?.api_key?.getAt(0)?.current_key
+}
+if (!firebaseKey) {
+    throw new GradleException("Firebase API key missing in google-services.json")
+}
 
 android {
     namespace "gr.eduinvoice"
@@ -18,10 +28,10 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 22
-        versionName "0.23.10"
+        versionCode 23
+        versionName "0.23.11"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey ?: ''}\""
+        buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }
 
     signingConfigs {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,7 +1,7 @@
 {
   "project_info": {
-    "project_number": "824043669156",
     "project_id": "eduinvoiceapp",
+    "project_number": "824043669156",
     "storage_bucket": "eduinvoiceapp.firebasestorage.app"
   },
   "client": [

--- a/app/src/test/java/gr/eduinvoice/BuildConfigTest.kt
+++ b/app/src/test/java/gr/eduinvoice/BuildConfigTest.kt
@@ -1,0 +1,11 @@
+package gr.eduinvoice
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BuildConfigTest {
+    @Test
+    fun firebaseApiKey_notEmpty() {
+        assertTrue(BuildConfig.FIREBASE_API_KEY.isNotBlank())
+    }
+}


### PR DESCRIPTION
## Summary
- source Firebase API key from google-services.json and include in BuildConfig
- verify Firebase API key is non-empty at runtime

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: Failed to fetch maven artifact org.robolectric:android-all-instrumented:4.4_r1-robolectric-r2-i4)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e0f98e2188330ae1ed7d1f2075a6f