### PR TITLE
fix(database): rebuild corrupt db in debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.11] - 2025-08-02
+### Fixed
+- Recover from corrupt database files in debug builds by deleting and rebuilding once on initialization failure.
+
 ## [0.23.10] - 2025-08-02
 ### Fixed
 - Logged database passphrase length and ensured SQLCipher libraries load before Room initialization.

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -23,6 +23,10 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    buildFeatures {
+        buildConfig true
+    }
 }
 
 dependencies {

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -8,6 +8,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import gr.eduinvoice.data.BuildConfig
 import gr.eduinvoice.data.database.DatabaseConstants
 import gr.eduinvoice.data.database.DatabaseInitException
 import gr.eduinvoice.data.database.EduInvoiceDatabase
@@ -40,6 +41,10 @@ object DatabaseModule {
             db.openHelper.writableDatabase
             db
         } catch (e: SQLiteException) {
+            if (!BuildConfig.DEBUG) {
+                Log.e("DatabaseModule", "Database open failed", e)
+                throw DatabaseInitException("Database open failed", e)
+            }
             Log.e("DatabaseModule", "Database open failed, attempting recovery", e)
             val dbFile = context.getDatabasePath(DatabaseConstants.DATABASE_NAME)
             try {


### PR DESCRIPTION
## Summary
- Add guarded recovery for Room initialization to delete and rebuild the DB in debug builds
- Enable BuildConfig generation for the data module and document the behavior in the changelog

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: 34 tests failed)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e0f8e8af883309ae33084664130b5