### PR TITLE
fix(security): use SecureRandom for passphrases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.12] - 2025-08-02
+### Fixed
+- Passphrase generation now uses `SecureRandom` and the database no longer logs passphrase length.
+### Added
+- Tests covering passphrase generation, encryption, and decryption utilities.
+
 ## [0.23.11] - 2025-08-02
 ### Fixed
 - Recover from corrupt database files in debug builds by deleting and rebuilding once on initialization failure.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 23
-        versionName "0.23.11"
+        versionName "0.23.12"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }

--- a/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/EduInvoiceDatabase.kt
@@ -50,10 +50,9 @@ abstract class EduInvoiceDatabase : RoomDatabase() {
             passphrase: ByteArray
         ): EduInvoiceDatabase {
             if (passphrase.isEmpty() || passphrase.all { it == 0.toByte() }) {
-                Log.e(TAG, "Invalid database passphrase; length=${'$'}{passphrase.size}")
+                Log.e(TAG, "Invalid database passphrase")
                 throw IllegalArgumentException("Invalid database passphrase")
             }
-            Log.d(TAG, "Using passphrase length ${'$'}{passphrase.size}")
             return INSTANCE ?: synchronized(this) {
                 val factory = SupportFactory(passphrase)
                 val instance = Room.databaseBuilder(

--- a/data/src/main/java/gr/eduinvoice/data/user/PassphraseCrypto.kt
+++ b/data/src/main/java/gr/eduinvoice/data/user/PassphraseCrypto.kt
@@ -7,12 +7,12 @@ import android.util.Base64
 import android.util.Log
 import java.security.GeneralSecurityException
 import java.security.KeyStore
+import java.security.SecureRandom
 import java.io.IOException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
-import kotlin.random.Random
 
 private const val KEY_ALIAS = "db_passphrase_key"
 private const val ENC_PREFIX = "enc:"
@@ -46,7 +46,7 @@ private fun getSecretKey(): SecretKey {
 
     fun generatePassphrase(): String {
         val bytes = ByteArray(32)
-        Random.nextBytes(bytes)
+        SecureRandom().nextBytes(bytes)
         return Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 

--- a/data/src/test/java/gr/eduinvoice/data/user/PassphraseCryptoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/user/PassphraseCryptoTest.kt
@@ -1,0 +1,46 @@
+package gr.eduinvoice.data.user
+
+import android.content.Context
+import android.util.Base64
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PassphraseCryptoTest {
+    private lateinit var crypto: PassphraseCrypto
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        crypto = PassphraseCrypto(context)
+    }
+
+    @Test
+    fun generatePassphraseProduces32Bytes() {
+        val passphrase = crypto.generatePassphrase()
+        val bytes = Base64.decode(passphrase, Base64.NO_WRAP)
+        assertEquals(32, bytes.size)
+    }
+
+    @Test
+    fun encryptDecryptRoundTrip() {
+        val passphrase = crypto.generatePassphrase()
+        val encrypted = crypto.encrypt(passphrase)
+        val decrypted = crypto.decrypt(encrypted)
+        assertEquals(passphrase, decrypted)
+    }
+
+    @Test
+    fun isEncryptedDetectsPrefix() {
+        val passphrase = crypto.generatePassphrase()
+        val encrypted = crypto.encrypt(passphrase)
+        assertTrue(crypto.isEncrypted(encrypted))
+        assertFalse(crypto.isEncrypted(passphrase))
+    }
+}


### PR DESCRIPTION
## Summary
- use `SecureRandom` for passphrase generation and remove length logging
- add unit tests for `PassphraseCrypto` to cover generation, encryption and prefix detection

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: Failed to fetch maven artifact org.robolectric:android-all-instrumented due to network unreachable)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e595ab21c83309ea82702bfd2ae1e