### PR TITLE
refactor(data): split financial logic and add transactional group lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.13] - 2025-08-02
+### Changed
+- Separated financial calculations into `FinancialService` and slimmed down `TutorBillingRepository`.
+- Group lesson creation now uses a Room transaction to ensure all-or-nothing inserts.
+### Added
+- Test verifying transaction rollback when a group lesson insert fails.
+
 ## [0.23.12] - 2025-08-02
 ### Fixed
 - Restoring students and updating lesson statuses now require matching owner IDs.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 23
-        versionName "0.23.12"
+        versionName "0.23.13"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }

--- a/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/invoice/InvoiceScreenTest.kt
@@ -81,6 +81,7 @@ class InvoiceScreenTest {
             override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = lessonFlow.asStateFlow()
             override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = lessonFlow.asStateFlow()
             override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = lessonFlow.asStateFlow()
+            override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> = lessons.map { it.id }
         }
         val groupDao = object : GroupDao {
             override suspend fun insertGroup(group: StudentGroup): Long = 1L

--- a/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/settings/SettingsScreenFlowTest.kt
@@ -188,6 +188,7 @@ class SettingsScreenFlowTest {
                 endDate: String,
                 userId: Long
             ): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
+            override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> = lessons.map { it.id }
         }
         val groupDao = object : GroupDao {
             override suspend fun insertGroup(group: StudentGroup) = 1L

--- a/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
+++ b/app/src/androidTest/java/gr/eduinvoice/ui/student/StudentScreenTest.kt
@@ -76,6 +76,7 @@ class StudentScreenTest {
             override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
             override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
             override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList<LessonWithStudent>())
+            override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> = lessons.map { it.id }
         }
         val groupDao = object : GroupDao {
             override suspend fun insertGroup(group: StudentGroup): Long = 1L

--- a/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
@@ -146,6 +146,11 @@ class HomeMenuViewModelTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
@@ -79,6 +79,11 @@ class InvoiceViewModelTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     private val groupDao = object : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
@@ -88,6 +88,11 @@ class LessonScreenTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     private val groupDao = object : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
@@ -207,6 +207,11 @@ class LessonViewModelGroupTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<gr.eduinvoice.data.database.LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<gr.eduinvoice.data.database.LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<gr.eduinvoice.data.database.LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao(

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -177,6 +177,11 @@ class FakeLessonDao(private val flow: MutableStateFlow<List<LessonWithStudent>>)
             flow.map { list -> list.filter { it.student.id == studentId && it.lesson.ownerId == userId } }
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -228,6 +228,11 @@ class LessonsViewModelTest {
             flow.map { list -> list.filter { it.student.id == studentId && it.lesson.ownerId == userId } }
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
@@ -165,6 +165,11 @@ class RevenueViewModelTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long): Flow<List<LessonWithStudent>> = flowOf(emptyList())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao : GroupDao {

--- a/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
@@ -190,6 +190,11 @@ class StudentViewModelTest {
         override fun getLessonsWithStudentsByStudent(studentId: Long, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsInDateRange(startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
         override fun getLessonsWithStudentsByStudentAndDateRange(studentId: Long, startDate: String, endDate: String, userId: Long) = flowOf(emptyList<gr.eduinvoice.data.database.LessonWithStudent>())
+
+        override suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+            lessons.forEach { insert(it) }
+            return lessons.map { it.id }
+        }
     }
 
     class FakeGroupDao : GroupDao {

--- a/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
+++ b/data/src/main/java/gr/eduinvoice/data/dao/LessonDao.kt
@@ -10,6 +10,13 @@ interface LessonDao {
     @Insert
     suspend fun insert(lesson: Lesson): Long
 
+    @Transaction
+    suspend fun insertGroupLessons(lessons: List<Lesson>): List<Long> {
+        val ids = mutableListOf<Long>()
+        lessons.forEach { lesson -> ids += insert(lesson) }
+        return ids
+    }
+
     @Update
     suspend fun update(lesson: Lesson)
 

--- a/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/RepositoryModule.kt
@@ -13,6 +13,7 @@ import gr.eduinvoice.data.repository.TutorBillingRepository
 import gr.eduinvoice.data.repository.GroupRepository
 import gr.eduinvoice.data.repository.UserRepository
 import gr.eduinvoice.data.repository.BackupRepository
+import gr.eduinvoice.data.service.FinancialService
 import gr.eduinvoice.data.database.EduInvoiceDatabase
 import javax.inject.Singleton
 
@@ -41,6 +42,13 @@ object RepositoryModule {
         lessonDao: LessonDao,
         groupDao: GroupDao
     ): TutorBillingRepository = TutorBillingRepository(studentDao, lessonDao, groupDao)
+
+    @Provides
+    @Singleton
+    fun provideFinancialService(
+        studentDao: StudentDao,
+        lessonDao: LessonDao
+    ): FinancialService = FinancialService(studentDao, lessonDao)
 
     @Provides
     @Singleton

--- a/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
+++ b/data/src/main/java/gr/eduinvoice/data/repository/TutorBillingRepository.kt
@@ -5,14 +5,8 @@ import gr.eduinvoice.data.dao.StudentDao
 import gr.eduinvoice.data.model.Lesson
 import gr.eduinvoice.data.model.Student
 import gr.eduinvoice.data.database.LessonWithStudent
-import gr.eduinvoice.data.model.calculateFee
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.temporal.TemporalAdjusters
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,8 +15,7 @@ import javax.inject.Singleton
  *
  * This class sits between the UI layer (ViewModels) and the data layer (DAOs),
  * providing a clean API that hides the complexity of data operations.
- * It offers methods to add, update, delete, and query students and lessons,
- * as well as utility functions for financial calculations.
+ * It offers methods to add, update, delete, and query students and lessons.
  *
  * @Inject tells Hilt to automatically provide the DAOs when creating this repository.
  * @Singleton ensures a single instance is used throughout the app.
@@ -98,14 +91,10 @@ class TutorBillingRepository @Inject constructor(
     suspend fun addGroupLesson(groupId: Long, lesson: Lesson, userId: Long): List<Long> {
         require(lesson.durationMinutes > 0) { "Lesson duration must be positive" }
         val students = groupDao.getStudentsForGroup(groupId, userId).first()
-        return students.map { student ->
-            lessonDao.insert(
-                lesson.copy(
-                    studentId = student.id,
-                    groupId = groupId
-                )
-            )
+        val lessons = students.map { student ->
+            lesson.copy(studentId = student.id, groupId = groupId)
         }
+        return lessonDao.insertGroupLessons(lessons)
     }
 
     /**
@@ -137,100 +126,4 @@ class TutorBillingRepository @Inject constructor(
         return lessonDao.getLessonsWithStudentsByStudent(studentId, userId)
     }
 
-    // ===== Financial Calculations =====
-
-    /**
-     * Holds weekly/monthly totals (plus lesson count) for a given student.
-     */
-    data class StudentFinancialSummary(
-        val student: Student,
-        val weekTotal: Double,
-        val monthTotal: Double,
-        val lessonCount: Int
-    )
-
-    /**
-     * Emits a list of [StudentFinancialSummary], one per active student.
-     */
-    fun getStudentFinancialSummaries(userId: Long): Flow<List<StudentFinancialSummary>> {
-        val today = LocalDate.now()
-        val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-        val weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
-        val monthStart = today.withDayOfMonth(1)
-        val monthEnd = today.withDayOfMonth(today.lengthOfMonth())
-
-        return combine(
-            studentDao.getAllActiveStudents(userId),
-            lessonDao.getAllLessons(userId)
-        ) { students, lessons ->
-            students.map { student ->
-                val studentLessons = lessons.filter { it.studentId == student.id }
-                val studentWeekLessons = studentLessons.filter { lesson ->
-                    val date = LocalDate.parse(lesson.date)
-                    !date.isBefore(weekStart) && !date.isAfter(weekEnd)
-                }
-                val studentMonthLessons = studentLessons.filter { lesson ->
-                    val date = LocalDate.parse(lesson.date)
-                    !date.isBefore(monthStart) && !date.isAfter(monthEnd)
-                }
-                val weekTotal = studentWeekLessons.sumOf { it.calculateFee(student) }
-                val monthTotal = studentMonthLessons.sumOf { it.calculateFee(student) }
-                StudentFinancialSummary(
-                    student = student,
-                    weekTotal = weekTotal,
-                    monthTotal = monthTotal,
-                    lessonCount = studentMonthLessons.size
-                )
-            }
-        }
-    }
-
-    /**
-     * Gets total earnings across all students for a given date range.
-     */
-    fun getTotalEarningsForDateRange(startDate: LocalDate, endDate: LocalDate, userId: Long): Flow<Double> {
-        return combine(
-            lessonDao.getLessonsInDateRange(startDate.toString(), endDate.toString(), userId),
-            studentDao.getAllActiveStudents(userId)
-        ) { lessons, students ->
-            val studentMap = students.associateBy { it.id }
-            lessons.sumOf { lesson ->
-                val student = studentMap[lesson.studentId] ?: return@sumOf 0.0
-                lesson.calculateFee(student)
-            }
-        }
-    }
-
-    /**
-     * Detailed report structure for a single student.
-     */
-    data class StudentDetailedReport(
-        val student: Student,
-        val totalLessons: Int,
-        val totalHours: Double,
-        val totalEarnings: Double,
-        val averageLessonDuration: Double,
-        val lastLessonDate: LocalDate?
-    )
-
-    /**
-     * Generates a detailed report for a single student.
-     */
-    suspend fun getStudentDetailedReport(studentId: Long, userId: Long): StudentDetailedReport? {
-        val student = studentDao.getStudentById(studentId, userId).first() ?: return null
-        val lessons: List<Lesson> = lessonDao.getLessonsByStudentId(studentId, userId).first()
-        val totalMinutes = lessons.sumOf { it.durationMinutes }
-        val totalHours = totalMinutes / 60.0
-        val totalEarnings = lessons.sumOf { it.calculateFee(student) }
-        val averageDuration = if (lessons.isNotEmpty()) totalMinutes.toDouble() / lessons.size else 0.0
-        val lastLessonDate = lessons.maxOfOrNull { LocalDate.parse(it.date) }
-        return StudentDetailedReport(
-            student = student,
-            totalLessons = lessons.size,
-            totalHours = totalHours,
-            totalEarnings = totalEarnings,
-            averageLessonDuration = averageDuration,
-            lastLessonDate = lastLessonDate
-        )
-    }
 }

--- a/data/src/main/java/gr/eduinvoice/data/service/FinancialService.kt
+++ b/data/src/main/java/gr/eduinvoice/data/service/FinancialService.kt
@@ -1,0 +1,108 @@
+package gr.eduinvoice.data.service
+
+import gr.eduinvoice.data.dao.LessonDao
+import gr.eduinvoice.data.dao.StudentDao
+import gr.eduinvoice.data.model.Lesson
+import gr.eduinvoice.data.model.Student
+import gr.eduinvoice.data.model.calculateFee
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FinancialService @Inject constructor(
+    private val studentDao: StudentDao,
+    private val lessonDao: LessonDao
+) {
+    data class StudentFinancialSummary(
+        val student: Student,
+        val weekTotal: Double,
+        val monthTotal: Double,
+        val lessonCount: Int
+    )
+
+    fun getStudentFinancialSummaries(userId: Long): Flow<List<StudentFinancialSummary>> {
+        val today = LocalDate.now()
+        val weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+        val monthStart = today.withDayOfMonth(1)
+        val monthEnd = today.withDayOfMonth(today.lengthOfMonth())
+
+        return combine(
+            studentDao.getAllActiveStudents(userId),
+            lessonDao.getAllLessons(userId)
+        ) { students, lessons ->
+            students.map { student ->
+                val studentLessons = lessons.filter { it.studentId == student.id }
+                val studentWeekLessons = studentLessons.filter { lesson ->
+                    val date = LocalDate.parse(lesson.date)
+                    !date.isBefore(weekStart) && !date.isAfter(weekEnd)
+                }
+                val studentMonthLessons = studentLessons.filter { lesson ->
+                    val date = LocalDate.parse(lesson.date)
+                    !date.isBefore(monthStart) && !date.isAfter(monthEnd)
+                }
+                val weekTotal = studentWeekLessons.sumOf { it.calculateFee(student) }
+                val monthTotal = studentMonthLessons.sumOf { it.calculateFee(student) }
+                StudentFinancialSummary(
+                    student = student,
+                    weekTotal = weekTotal,
+                    monthTotal = monthTotal,
+                    lessonCount = studentMonthLessons.size
+                )
+            }
+        }
+    }
+
+    fun getTotalEarningsForDateRange(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        userId: Long
+    ): Flow<Double> {
+        return combine(
+            lessonDao.getLessonsInDateRange(startDate.toString(), endDate.toString(), userId),
+            studentDao.getAllActiveStudents(userId)
+        ) { lessons, students ->
+            val studentMap = students.associateBy { it.id }
+            lessons.sumOf { lesson ->
+                val student = studentMap[lesson.studentId] ?: return@sumOf 0.0
+                lesson.calculateFee(student)
+            }
+        }
+    }
+
+    data class StudentDetailedReport(
+        val student: Student,
+        val totalLessons: Int,
+        val totalHours: Double,
+        val totalEarnings: Double,
+        val averageLessonDuration: Double,
+        val lastLessonDate: LocalDate?
+    )
+
+    suspend fun getStudentDetailedReport(
+        studentId: Long,
+        userId: Long
+    ): StudentDetailedReport? {
+        val student = studentDao.getStudentById(studentId, userId).first() ?: return null
+        val lessons: List<Lesson> = lessonDao.getLessonsByStudentId(studentId, userId).first()
+        val totalMinutes = lessons.sumOf { it.durationMinutes }
+        val totalHours = totalMinutes / 60.0
+        val totalEarnings = lessons.sumOf { it.calculateFee(student) }
+        val averageDuration = if (lessons.isNotEmpty()) totalMinutes.toDouble() / lessons.size else 0.0
+        val lastLessonDate = lessons.maxOfOrNull { LocalDate.parse(it.date) }
+        return StudentDetailedReport(
+            student = student,
+            totalLessons = lessons.size,
+            totalHours = totalHours,
+            totalEarnings = totalEarnings,
+            averageLessonDuration = averageDuration,
+            lastLessonDate = lastLessonDate
+        )
+    }
+}

--- a/domain/src/test/java/gr/eduinvoice/domain/lesson/AddGroupLessonIntegrationTest.kt
+++ b/domain/src/test/java/gr/eduinvoice/domain/lesson/AddGroupLessonIntegrationTest.kt
@@ -17,6 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 class AddGroupLessonIntegrationTest {
@@ -81,5 +82,23 @@ class AddGroupLessonIntegrationTest {
         assertEquals(3, ids.size)
         val lessons = db.lessonDao().getAllLessons(userId).first()
         assertEquals(3, lessons.size)
+    }
+
+    @Test
+    fun partialFailureRollsBack() = runBlocking {
+        val userId = 1L
+        val s1 = db.studentDao().insert(Student(ownerId = userId, name = "Dan", surname = "", parentMobile = "", className = "", rate = 10.0))
+        val s2 = db.studentDao().insert(Student(ownerId = userId, name = "Eve", surname = "", parentMobile = "", className = "", rate = 12.0))
+        val gId = db.groupDao().insertGroup(StudentGroup(ownerId = userId, name = "Group C"))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s1, ownerId = userId))
+        db.groupDao().insertCrossRef(GroupStudentCrossRef(groupId = gId, studentId = s2, ownerId = userId))
+
+        val lesson = Lesson(id = 1, ownerId = userId, studentId = 0, date = "2024-03-01", startTime = "08:00", durationMinutes = 60)
+        val useCase = AddGroupLesson(repository)
+
+        assertFailsWith<Exception> { useCase(gId, lesson, userId) }
+
+        val lessons = db.lessonDao().getAllLessons(userId).first()
+        assertEquals(0, lessons.size)
     }
 }


### PR DESCRIPTION
## Summary
- move fee and report calculations from `TutorBillingRepository` into new `FinancialService`
- ensure multi-student lesson inserts run inside a Room transaction
- provide rollback test and expose `FinancialService` via Hilt

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: MavenArtifactFetcher SocketException)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688e6d1fab90833085b3c459861648db