### PR TITLE
fix(test): register bouncycastle provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.15] - 2025-08-02
+### Fixed
+- Register BouncyCastle provider during Robolectric tests to resolve cryptography errors.
+### Build
+- Added BouncyCastle provider dependency for test scope.
+
 ## [0.23.14] - 2025-08-02
 ### Changed
 - Gracefully handle DataStore I/O errors when fetching DB passphrase.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 25
-        versionName "0.23.14"
+        versionCode 26
+        versionName "0.23.15"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }
@@ -146,6 +146,7 @@ android {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
     testImplementation "androidx.compose.ui:ui-test-junit4"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.70"
     androidTestImplementation "androidx.test.ext:junit:1.2.1"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.6.1"
     androidTestImplementation platform("androidx.compose:compose-bom:2025.06.00")

--- a/app/src/test/java/gr/eduinvoice/BouncyCastleTestRunner.kt
+++ b/app/src/test/java/gr/eduinvoice/BouncyCastleTestRunner.kt
@@ -1,0 +1,18 @@
+package gr.eduinvoice
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.BeforeClass
+import org.robolectric.RobolectricTestRunner
+import java.security.Security
+
+class BouncyCastleTestRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setupProvider() {
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.addProvider(BouncyCastleProvider())
+            }
+        }
+    }
+}

--- a/app/src/test/java/gr/eduinvoice/data/StudentDaoArchiveTest.kt
+++ b/app/src/test/java/gr/eduinvoice/data/StudentDaoArchiveTest.kt
@@ -14,9 +14,9 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class StudentDaoArchiveTest {
 
     private lateinit var db: EduInvoiceDatabase

--- a/app/src/test/java/gr/eduinvoice/ui/components/StudentCardTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/components/StudentCardTest.kt
@@ -8,9 +8,9 @@ import gr.eduinvoice.data.model.StudentWithEarnings
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class StudentCardTest {
     @get:Rule
     val composeRule = createComposeRule()

--- a/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/groups/GroupViewModelTest.kt
@@ -24,9 +24,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class GroupViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/home/HomeMenuViewModelTest.kt
@@ -47,9 +47,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class HomeMenuViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoicePdfTest.kt
@@ -10,12 +10,12 @@ import gr.eduinvoice.data.model.Student
 import gr.eduinvoice.utils.PdfGenerator
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 import java.io.File
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class InvoicePdfTest {
     @Test
     fun createInvoicePdfWritesToFile() {

--- a/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/invoice/InvoiceViewModelTest.kt
@@ -25,9 +25,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class InvoiceViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonScreenTest.kt
@@ -40,9 +40,9 @@ import kotlinx.coroutines.flow.map
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LessonScreenTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lesson/LessonViewModelGroupTest.kt
@@ -28,9 +28,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LessonViewModelGroupTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsScreenTest.kt
@@ -29,10 +29,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 import java.time.LocalDate
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LessonsScreenTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/lessons/LessonsViewModelTest.kt
@@ -24,10 +24,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.assertEquals
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 import java.time.LocalDate
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LessonsViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/revenue/RevenueViewModelTest.kt
@@ -47,10 +47,10 @@ import org.junit.Rule
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 import java.time.LocalDate
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class RevenueViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/settings/SettingsViewModelTest.kt
@@ -27,9 +27,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class SettingsViewModelTest {
     @get:Rule val dispatcherRule = MainDispatcherRule()
 

--- a/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/student/StudentViewModelTest.kt
@@ -28,9 +28,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class StudentViewModelTest {
 
     @get:Rule

--- a/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/LoginViewModelTest.kt
@@ -21,9 +21,9 @@ import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LoginViewModelTest {
     @get:Rule val dispatcherRule = MainDispatcherRule()
 

--- a/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
+++ b/app/src/test/java/gr/eduinvoice/ui/user/RegisterViewModelTest.kt
@@ -21,9 +21,9 @@ import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class RegisterViewModelTest {
     @get:Rule val dispatcherRule = MainDispatcherRule()
 

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     testImplementation "androidx.test:core:1.5.0"
     testImplementation "org.robolectric:robolectric:4.11.1"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0"
+    testImplementation "org.bouncycastle:bcprov-jdk15on:1.70"
 }
 
 ksp {

--- a/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/BackupRepositoryTest.kt
@@ -13,9 +13,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class BackupRepositoryTest {
     private lateinit var db: EduInvoiceDatabase
     private lateinit var repo: BackupRepository

--- a/data/src/test/java/gr/eduinvoice/data/BouncyCastleTestRunner.kt
+++ b/data/src/test/java/gr/eduinvoice/data/BouncyCastleTestRunner.kt
@@ -1,0 +1,18 @@
+package gr.eduinvoice.data
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.BeforeClass
+import org.robolectric.RobolectricTestRunner
+import java.security.Security
+
+class BouncyCastleTestRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setupProvider() {
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.addProvider(BouncyCastleProvider())
+            }
+        }
+    }
+}

--- a/data/src/test/java/gr/eduinvoice/data/DatabaseProviderRecoveryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/DatabaseProviderRecoveryTest.kt
@@ -11,10 +11,10 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 import org.junit.Assert.assertTrue
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class DatabaseProviderRecoveryTest {
     private lateinit var context: Context
     private lateinit var prefs: UserPreferencesRepository

--- a/data/src/test/java/gr/eduinvoice/data/DatabaseRecoveryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/DatabaseRecoveryTest.kt
@@ -12,10 +12,10 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 import org.junit.Assert.assertTrue
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class DatabaseRecoveryTest {
     private lateinit var context: Context
     private lateinit var prefs: UserPreferencesRepository

--- a/data/src/test/java/gr/eduinvoice/data/GroupDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/GroupDaoTest.kt
@@ -16,9 +16,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class GroupDaoTest {
 
     private lateinit var db: EduInvoiceDatabase

--- a/data/src/test/java/gr/eduinvoice/data/LegacyMigrationTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/LegacyMigrationTest.kt
@@ -17,9 +17,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LegacyMigrationTest {
     private lateinit var context: Context
     private lateinit var prefs: UserPreferencesRepository

--- a/data/src/test/java/gr/eduinvoice/data/LessonDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/LessonDaoTest.kt
@@ -15,9 +15,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class LessonDaoTest {
 
     private lateinit var db: EduInvoiceDatabase

--- a/data/src/test/java/gr/eduinvoice/data/StudentDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/StudentDaoTest.kt
@@ -14,9 +14,9 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class StudentDaoTest {
 
     private lateinit var db: EduInvoiceDatabase

--- a/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/dao/UserDaoTest.kt
@@ -11,9 +11,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class UserDaoTest {
     private lateinit var db: EduInvoiceDatabase
     private lateinit var dao: UserDao

--- a/data/src/test/java/gr/eduinvoice/data/user/PassphraseCryptoTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/user/PassphraseCryptoTest.kt
@@ -9,9 +9,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class PassphraseCryptoTest {
     private lateinit var crypto: PassphraseCrypto
 

--- a/data/src/test/java/gr/eduinvoice/data/user/UserPreferencesRepositoryTest.kt
+++ b/data/src/test/java/gr/eduinvoice/data/user/UserPreferencesRepositoryTest.kt
@@ -13,10 +13,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import gr.eduinvoice.data.BouncyCastleTestRunner
 import java.io.IOException
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(BouncyCastleTestRunner::class)
 class UserPreferencesRepositoryTest {
     private lateinit var repo: UserPreferencesRepository
 


### PR DESCRIPTION
## Summary
- scope test deps to include BouncyCastle provider and bump app version
- register BouncyCastle provider via custom Robolectric runner
- update Robolectric tests to use the new runner

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: MavenArtifactFetcher SocketException)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688ea24bf7c483309adff2c448b088b9