### PR TITLE
fix(main): initialize nav controller before nav drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.18] - 2025-08-03
+### Fixed
+- Initialize `navController` before usage to avoid startup crash.
+
 ## [0.23.17] - 2025-08-02
 ### Fixed
 - Groups now store owner IDs and link selected students on save.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 27
-        versionName "0.23.17"
+        versionCode 28
+        versionName "0.23.18"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }

--- a/app/src/main/java/gr/eduinvoice/MainActivity.kt
+++ b/app/src/main/java/gr/eduinvoice/MainActivity.kt
@@ -54,9 +54,6 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
             drawerLayout.addDrawerListener(toggle)
             toggle.syncState()
 
-            findViewById<NavigationView>(R.id.navigation_view)
-                .setNavigationItemSelectedListener(this)
-
             findViewById<ComposeView>(R.id.compose_view).setContent {
                 navController = rememberNavController()
                 val viewModel: SettingsViewModel = hiltViewModel()
@@ -80,6 +77,9 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                     }
                 }
             }
+
+            findViewById<NavigationView>(R.id.navigation_view)
+                .setNavigationItemSelectedListener(this)
         } catch (e: DatabaseInitException) {
             showDatabaseErrorDialog()
         }


### PR DESCRIPTION
- WHAT changed
  - Move navController initialization before setting navigation drawer listener.
  - Bump version to 0.23.18 and update changelog.
- WHY it matters
  - Prevents crash from uninitialized navController when navigation items are selected.
- HOW to test (`./gradlew test`)

Checklist:
- [x] Version bumped and `CHANGELOG.md` updated
- [ ] Unit tests passing
- [ ] Lint shows 0 new warnings
- [ ] No TODOs or commented-out code left
- [ ] `./gradlew assemble` succeeds on CI

------
https://chatgpt.com/codex/tasks/task_e_688f70289fe48330934de9b78496fbe8