### PR TITLE
fix(data): validate DB key and recover from corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.18] - 2025-08-02
+### Fixed
+- Validate SQLCipher passphrase and rebuild database after removing corrupt file in debug builds.
+
 ## [0.23.17] - 2025-08-02
 ### Fixed
 - Groups now store owner IDs and link selected students on save.

--- a/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
+++ b/data/src/main/java/gr/eduinvoice/data/di/DatabaseModule.kt
@@ -31,15 +31,23 @@ object DatabaseModule {
         prefs: UserPreferencesRepository
     ): EduInvoiceDatabase {
         val pass = runBlocking(Dispatchers.IO) { prefs.getDbPassphrase() }
-        require(pass.isNotEmpty()) { "Database passphrase unavailable" }
+        require(pass.isNotBlank()) { "Database passphrase unavailable" }
         SQLiteDatabase.loadLibs(context)
         val passphrase = SQLiteDatabase.getBytes(pass.toCharArray())
+        require(passphrase.isNotEmpty() && passphrase.any { it != 0.toByte() }) {
+            "Invalid database passphrase"
+        }
         Log.d("DatabaseModule", "Passphrase length: ${'$'}{passphrase.size}")
-        val db = try {
+
+        fun openDatabase(): EduInvoiceDatabase {
             val db = EduInvoiceDatabase.getDatabase(context, passphrase.copyOf())
             // Force open to catch corruption immediately
             db.openHelper.writableDatabase
-            db
+            return db
+        }
+
+        val db = try {
+            openDatabase()
         } catch (e: SQLiteException) {
             if (!BuildConfig.DEBUG) {
                 Log.e("DatabaseModule", "Database open failed", e)
@@ -56,13 +64,12 @@ object DatabaseModule {
                     )
                     throw DatabaseInitException("Unable to delete corrupt database", e)
                 }
-                val db = EduInvoiceDatabase.getDatabase(context, passphrase.copyOf())
-                db.openHelper.writableDatabase
+                val recovered = openDatabase()
                 legacyJson?.let {
-                    val repo = BackupRepository(db)
+                    val repo = BackupRepository(recovered)
                     runBlocking(Dispatchers.IO) { repo.restoreFromJson(it) }
                 }
-                db
+                recovered
             } catch (recovery: Exception) {
                 Log.e("DatabaseModule", "Database recovery failed", recovery)
                 throw DatabaseInitException("Database recovery failed", recovery)


### PR DESCRIPTION
## Summary
- ensure SQLCipher passphrase is non-blank and non-zero before opening Room
- retry database creation after deleting a corrupt file in debug builds
- document change in changelog

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: 24 tests completed, 24 failed; see reports)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_688f70403b1c8330be4d89b69cf7e156