### PR TITLE
fix(test): import PdfDocument from android.graphics.pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.19] - 2025-08-03
+### Fixed
+- Use `android.graphics.pdf.PdfDocument` in test utilities to resolve compilation errors.
+
 ## [0.23.18] - 2025-08-03
 ### Fixed
 - Validate SQLCipher passphrase and rebuild database after removing corrupt file in debug builds.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 28
-        versionName "0.23.18"
+        versionCode 29
+        versionName "0.23.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }

--- a/app/src/test/java/gr/eduinvoice/testinfrastructure/PdfTestEnvironment.kt
+++ b/app/src/test/java/gr/eduinvoice/testinfrastructure/PdfTestEnvironment.kt
@@ -3,7 +3,7 @@ package gr.eduinvoice.testinfrastructure
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
-import android.graphics.PdfDocument
+import android.graphics.pdf.PdfDocument
 import android.graphics.Rect
 import android.graphics.Typeface
 import android.net.Uri


### PR DESCRIPTION
## Summary
- replace incorrect `android.graphics.PdfDocument` import with `android.graphics.pdf.PdfDocument` in test infrastructure
- bump app version to 0.23.19 and document change

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: compilation error in unrelated tests)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_6890bacefc3083308d7fc2bce00f4f1a