### PR TITLE
chore(release): 0.23.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.19] - 2025-08-04
+### Changed
+- Overhauled test infrastructure for clearer PDF and Compose setups.
+- Improved group data handling for more reliable relationships.
+
 ## [0.23.18] - 2025-08-03
 ### Fixed
 - Validate SQLCipher passphrase and rebuild database after removing corrupt file in debug builds.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdk 26
         targetSdk 35
         versionCode 28
-        versionName "0.23.18"
+        versionName "0.23.19"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
     }


### PR DESCRIPTION
## Summary
- bump versionName to 0.23.19
- document test environment overhaul and group data improvements

## Testing
- `./gradlew clean`
- `./gradlew assemble`
- `./gradlew test` *(fails: unresolved references in test infrastructure)*
- `./gradlew lintDebug`


------
https://chatgpt.com/codex/tasks/task_e_6890b8da760c83308e8c1131c95a4272