### PR TITLE
fix(data): add default student rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] - 2025-08-22
+
+### Fixed
+- Ensure student rate defaults to 0.0 and backfill null values during migration
+
 ## [0.29.0] - 2025-08-22
 
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ android {
         applicationId "gr.eduinvoice"
         minSdk 26
         targetSdk 35
-        versionCode 47  // Increment version code
-        versionName "0.29.0"  // Increment version name for RBAC feature
+        versionCode 48  // Increment version code
+        versionName "0.29.1"  // Increment version name for rate default fix
         testInstrumentationRunner "com.google.dagger.hilt.android.testing.HiltTestRunner"
         buildConfigField "String", "FIREBASE_API_KEY", "\"${firebaseKey}\""
         buildConfigField "boolean", "LEGACY_ROUTES_ENABLED", "true"

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/10.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/10.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -51,7 +51,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/11.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/11.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -51,7 +51,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/12.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/12.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -51,7 +51,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/13.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/13.json
@@ -1,338 +1,329 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  13,
-                     "identityHash":  "5267dfebb67d389b9f4b9d7d3cf7e44f",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u00275267dfebb67d389b9f4b9d7d3cf7e44f\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "5267dfebb67d389b9f4b9d7d3cf7e44f",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5267dfebb67d389b9f4b9d7d3cf7e44f')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/14.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/14.json
@@ -1,366 +1,357 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  14,
-                     "identityHash":  "34f31be211beb4e9c420e05b6eb37878",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u002734f31be211beb4e9c420e05b6eb37878\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "34f31be211beb4e9c420e05b6eb37878",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '34f31be211beb4e9c420e05b6eb37878')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/15.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/15.json
@@ -1,366 +1,357 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  15,
-                     "identityHash":  "34f31be211beb4e9c420e05b6eb37878",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u002734f31be211beb4e9c420e05b6eb37878\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "34f31be211beb4e9c420e05b6eb37878",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '34f31be211beb4e9c420e05b6eb37878')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/16.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/16.json
@@ -1,385 +1,376 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  16,
-                     "identityHash":  "7c58607c19ff0264ad7ae2f89752a498",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u00277c58607c19ff0264ad7ae2f89752a498\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "7c58607c19ff0264ad7ae2f89752a498",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7c58607c19ff0264ad7ae2f89752a498')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/17.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/17.json
@@ -1,392 +1,383 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  17,
-                     "identityHash":  "3f1076c1cf751852517e18a2368eb8f4",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u00273f1076c1cf751852517e18a2368eb8f4\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "3f1076c1cf751852517e18a2368eb8f4",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3f1076c1cf751852517e18a2368eb8f4')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/18.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/18.json
@@ -1,551 +1,534 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  18,
-                     "identityHash":  "d126c280d217f2fb25bd02f8ceca876a",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_master_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_master_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_absences",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupLessonId",
-                                                             "columnName":  "groupLessonId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_absences_groupLessonId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_absences_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "group_lesson_master",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u0027d126c280d217f2fb25bd02f8ceca876a\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "d126c280d217f2fb25bd02f8ceca876a",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_master_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_lesson_master_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_absences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupLessonId",
+            "columnName": "groupLessonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_absences_groupLessonId",
+            "unique": false,
+            "columnNames": [
+              "groupLessonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
+          },
+          {
+            "name": "index_group_lesson_absences_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_lesson_master",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupLessonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd126c280d217f2fb25bd02f8ceca876a')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/19.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/19.json
@@ -1,557 +1,540 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  19,
-                     "identityHash":  "fd2dfbd0d336e085118677c84ec69596",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `masterId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "masterId",
-                                                             "columnName":  "masterId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_master_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_master_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_absences",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupLessonId",
-                                                             "columnName":  "groupLessonId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_absences_groupLessonId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_absences_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "group_lesson_master",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u0027fd2dfbd0d336e085118677c84ec69596\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "fd2dfbd0d336e085118677c84ec69596",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `masterId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "masterId",
+            "columnName": "masterId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_master_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_lesson_master_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_absences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupLessonId",
+            "columnName": "groupLessonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_absences_groupLessonId",
+            "unique": false,
+            "columnNames": [
+              "groupLessonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
+          },
+          {
+            "name": "index_group_lesson_absences_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_lesson_master",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupLessonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fd2dfbd0d336e085118677c84ec69596')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/20.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/20.json
@@ -1,654 +1,631 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  20,
-                     "identityHash":  "408ecea7ab781c16e316d187974752f4",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `masterId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "masterId",
-                                                             "columnName":  "masterId",
-                                                             "affinity":  "INTEGER",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_master_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_master_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_absences",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupLessonId",
-                                                             "columnName":  "groupLessonId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_absences_groupLessonId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_absences_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "group_lesson_master",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "invoice_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `invoiceNumber` TEXT NOT NULL, `invoiceDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "invoiceNumber",
-                                                             "columnName":  "invoiceNumber",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "invoiceDate",
-                                                             "columnName":  "invoiceDate",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isArchived",
-                                                             "columnName":  "isArchived",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_invoice_master_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_invoice_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_invoice_master_invoiceDate",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "invoiceDate"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_invoice_master_invoiceDate` ON `${TABLE_NAME}` (`invoiceDate`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_invoice_master_invoiceNumber",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "invoiceNumber"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_invoice_master_invoiceNumber` ON `${TABLE_NAME}` (`invoiceNumber`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u0027408ecea7ab781c16e316d187974752f4\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "408ecea7ab781c16e316d187974752f4",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER DEFAULT NULL, `masterId` INTEGER DEFAULT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "masterId",
+            "columnName": "masterId",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_master_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_lesson_master_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_absences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupLessonId",
+            "columnName": "groupLessonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_absences_groupLessonId",
+            "unique": false,
+            "columnNames": [
+              "groupLessonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
+          },
+          {
+            "name": "index_group_lesson_absences_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_lesson_master",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupLessonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "invoice_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `invoiceNumber` TEXT NOT NULL, `invoiceDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invoiceNumber",
+            "columnName": "invoiceNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invoiceDate",
+            "columnName": "invoiceDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_invoice_master_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_invoice_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_invoice_master_invoiceDate",
+            "unique": false,
+            "columnNames": [
+              "invoiceDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_invoice_master_invoiceDate` ON `${TABLE_NAME}` (`invoiceDate`)"
+          },
+          {
+            "name": "index_invoice_master_invoiceNumber",
+            "unique": true,
+            "columnNames": [
+              "invoiceNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_invoice_master_invoiceNumber` ON `${TABLE_NAME}` (`invoiceNumber`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '408ecea7ab781c16e316d187974752f4')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/21.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/21.json
@@ -1,883 +1,846 @@
 {
-    "formatVersion":  1,
-    "database":  {
-                     "version":  21,
-                     "identityHash":  "1158a0bf33e2ca4e4fe24760183209de",
-                     "entities":  [
-                                      {
-                                          "tableName":  "students",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT \u0027\u0027, `parentMobile` TEXT NOT NULL DEFAULT \u0027\u0027, `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT \u0027\u0027, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT \u0027hourly\u0027, `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "surname",
-                                                             "columnName":  "surname",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentMobile",
-                                                             "columnName":  "parentMobile",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "parentEmail",
-                                                             "columnName":  "parentEmail",
-                                                             "affinity":  "TEXT",
-                                                             "defaultValue":  "NULL"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027hourly\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER, `masterId` INTEGER, `invoiceMasterId` INTEGER, `paymentBatchId` INTEGER, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "masterId",
-                                                             "columnName":  "masterId",
-                                                             "affinity":  "INTEGER"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "invoiceMasterId",
-                                                             "columnName":  "invoiceMasterId",
-                                                             "affinity":  "INTEGER"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "paymentBatchId",
-                                                             "columnName":  "paymentBatchId",
-                                                             "affinity":  "INTEGER"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isPaid",
-                                                             "columnName":  "isPaid",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isInvoiced",
-                                                             "columnName":  "isInvoiced",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_lessons_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_masterId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "masterId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_masterId` ON `${TABLE_NAME}` (`masterId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_invoiceMasterId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "invoiceMasterId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_invoiceMasterId` ON `${TABLE_NAME}` (`invoiceMasterId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_lessons_paymentBatchId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "paymentBatchId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lessons_paymentBatchId` ON `${TABLE_NAME}` (`paymentBatchId`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "students",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "student_groups",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "name",
-                                                             "columnName":  "name",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "className",
-                                                             "columnName":  "className",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rate",
-                                                             "columnName":  "rate",
-                                                             "affinity":  "REAL",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "rateType",
-                                                             "columnName":  "rateType",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isActive",
-                                                             "columnName":  "isActive",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "1"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "group_student_cross_ref",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "groupId",
-                                                                                 "studentId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_student_cross_ref_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "users",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT \u0027\u0027, `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "username",
-                                                             "columnName":  "username",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "passwordHash",
-                                                             "columnName":  "passwordHash",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "fullName",
-                                                             "columnName":  "fullName",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "subjectSpecialty",
-                                                             "columnName":  "subjectSpecialty",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "\u0027\u0027"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "yearsExperience",
-                                                             "columnName":  "yearsExperience",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_users_username",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "username"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupId",
-                                                             "columnName":  "groupId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "date",
-                                                             "columnName":  "date",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "startTime",
-                                                             "columnName":  "startTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "durationMinutes",
-                                                             "columnName":  "durationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_master_groupId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_master_date",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "date"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "group_lesson_absences",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "groupLessonId",
-                                                             "columnName":  "groupLessonId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_group_lesson_absences_groupLessonId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_group_lesson_absences_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          }
-                                                      ],
-                                          "foreignKeys":  [
-                                                              {
-                                                                  "table":  "group_lesson_master",
-                                                                  "onDelete":  "CASCADE",
-                                                                  "onUpdate":  "NO ACTION",
-                                                                  "columns":  [
-                                                                                  "groupLessonId"
-                                                                              ],
-                                                                  "referencedColumns":  [
-                                                                                            "id"
-                                                                                        ]
-                                                              }
-                                                          ]
-                                      },
-                                      {
-                                          "tableName":  "invoice_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `invoiceNumber` TEXT NOT NULL, `invoiceDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "invoiceNumber",
-                                                             "columnName":  "invoiceNumber",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "invoiceDate",
-                                                             "columnName":  "invoiceDate",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isArchived",
-                                                             "columnName":  "isArchived",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_invoice_master_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_invoice_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_invoice_master_invoiceDate",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "invoiceDate"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_invoice_master_invoiceDate` ON `${TABLE_NAME}` (`invoiceDate`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_invoice_master_invoiceNumber",
-                                                              "unique":  true,
-                                                              "columnNames":  [
-                                                                                  "invoiceNumber"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE UNIQUE INDEX IF NOT EXISTS `index_invoice_master_invoiceNumber` ON `${TABLE_NAME}` (`invoiceNumber`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "payment_batch_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER, `batchDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "studentId",
-                                                             "columnName":  "studentId",
-                                                             "affinity":  "INTEGER"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "batchDate",
-                                                             "columnName":  "batchDate",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "isArchived",
-                                                             "columnName":  "isArchived",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_payment_batch_master_studentId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "studentId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_payment_batch_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_payment_batch_master_batchDate",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "batchDate"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_payment_batch_master_batchDate` ON `${TABLE_NAME}` (`batchDate`)"
-                                                          }
-                                                      ]
-                                      },
-                                      {
-                                          "tableName":  "reschedule_master",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `title` TEXT, `newDate` TEXT NOT NULL, `newStartTime` TEXT NOT NULL, `newDurationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "id",
-                                                             "columnName":  "id",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "ownerId",
-                                                             "columnName":  "ownerId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "title",
-                                                             "columnName":  "title",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "newDate",
-                                                             "columnName":  "newDate",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "newStartTime",
-                                                             "columnName":  "newStartTime",
-                                                             "affinity":  "TEXT",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "newDurationMinutes",
-                                                             "columnName":  "newDurationMinutes",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "notes",
-                                                             "columnName":  "notes",
-                                                             "affinity":  "TEXT"
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lastModified",
-                                                             "columnName":  "lastModified",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true,
-                                                             "defaultValue":  "0"
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  true,
-                                                             "columnNames":  [
-                                                                                 "id"
-                                                                             ]
-                                                         }
-                                      },
-                                      {
-                                          "tableName":  "reschedule_master_lessons",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`masterId` INTEGER NOT NULL, `lessonId` INTEGER NOT NULL, PRIMARY KEY(`masterId`, `lessonId`))",
-                                          "fields":  [
-                                                         {
-                                                             "fieldPath":  "masterId",
-                                                             "columnName":  "masterId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         },
-                                                         {
-                                                             "fieldPath":  "lessonId",
-                                                             "columnName":  "lessonId",
-                                                             "affinity":  "INTEGER",
-                                                             "notNull":  true
-                                                         }
-                                                     ],
-                                          "primaryKey":  {
-                                                             "autoGenerate":  false,
-                                                             "columnNames":  [
-                                                                                 "masterId",
-                                                                                 "lessonId"
-                                                                             ]
-                                                         },
-                                          "indices":  [
-                                                          {
-                                                              "name":  "index_reschedule_master_lessons_masterId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "masterId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_reschedule_master_lessons_masterId` ON `${TABLE_NAME}` (`masterId`)"
-                                                          },
-                                                          {
-                                                              "name":  "index_reschedule_master_lessons_lessonId",
-                                                              "unique":  false,
-                                                              "columnNames":  [
-                                                                                  "lessonId"
-                                                                              ],
-                                                              "orders":  [
-
-                                                                         ],
-                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_reschedule_master_lessons_lessonId` ON `${TABLE_NAME}` (`lessonId`)"
-                                                          }
-                                                      ]
-                                      }
-                                  ],
-                     "setupQueries":  [
-                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u00271158a0bf33e2ca4e4fe24760183209de\u0027)"
-                                      ]
-                 }
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "1158a0bf33e2ca4e4fe24760183209de",
+    "entities": [
+      {
+        "tableName": "students",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "surname",
+            "columnName": "surname",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentMobile",
+            "columnName": "parentMobile",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "parentEmail",
+            "columnName": "parentEmail",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'hourly'"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `groupId` INTEGER, `masterId` INTEGER, `invoiceMasterId` INTEGER, `paymentBatchId` INTEGER, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `isPaid` INTEGER NOT NULL DEFAULT 0, `isInvoiced` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`studentId`) REFERENCES `students`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "masterId",
+            "columnName": "masterId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "invoiceMasterId",
+            "columnName": "invoiceMasterId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paymentBatchId",
+            "columnName": "paymentBatchId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInvoiced",
+            "columnName": "isInvoiced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lessons_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_lessons_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_date` ON `${TABLE_NAME}` (`date`)"
+          },
+          {
+            "name": "index_lessons_masterId",
+            "unique": false,
+            "columnNames": [
+              "masterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_masterId` ON `${TABLE_NAME}` (`masterId`)"
+          },
+          {
+            "name": "index_lessons_invoiceMasterId",
+            "unique": false,
+            "columnNames": [
+              "invoiceMasterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_invoiceMasterId` ON `${TABLE_NAME}` (`invoiceMasterId`)"
+          },
+          {
+            "name": "index_lessons_paymentBatchId",
+            "unique": false,
+            "columnNames": [
+              "paymentBatchId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lessons_paymentBatchId` ON `${TABLE_NAME}` (`paymentBatchId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "students",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "studentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "student_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `name` TEXT NOT NULL, `className` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL, `isActive` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rateType",
+            "columnName": "rateType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "group_student_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `ownerId` INTEGER NOT NULL, PRIMARY KEY(`groupId`, `studentId`))",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "groupId",
+            "studentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_student_cross_ref_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_group_student_cross_ref_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_student_cross_ref_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `passwordHash` TEXT NOT NULL, `fullName` TEXT NOT NULL, `subjectSpecialty` TEXT NOT NULL DEFAULT '', `yearsExperience` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordHash",
+            "columnName": "passwordHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSpecialty",
+            "columnName": "subjectSpecialty",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "yearsExperience",
+            "columnName": "yearsExperience",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_username",
+            "unique": true,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupId` INTEGER NOT NULL, `date` TEXT NOT NULL, `startTime` TEXT NOT NULL, `durationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_master_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_lesson_master_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_master_date` ON `${TABLE_NAME}` (`date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "group_lesson_absences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `groupLessonId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, FOREIGN KEY(`groupLessonId`) REFERENCES `group_lesson_master`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "groupLessonId",
+            "columnName": "groupLessonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_lesson_absences_groupLessonId",
+            "unique": false,
+            "columnNames": [
+              "groupLessonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_groupLessonId` ON `${TABLE_NAME}` (`groupLessonId`)"
+          },
+          {
+            "name": "index_group_lesson_absences_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_lesson_absences_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_lesson_master",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupLessonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "invoice_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER NOT NULL, `invoiceNumber` TEXT NOT NULL, `invoiceDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invoiceNumber",
+            "columnName": "invoiceNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invoiceDate",
+            "columnName": "invoiceDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_invoice_master_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_invoice_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_invoice_master_invoiceDate",
+            "unique": false,
+            "columnNames": [
+              "invoiceDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_invoice_master_invoiceDate` ON `${TABLE_NAME}` (`invoiceDate`)"
+          },
+          {
+            "name": "index_invoice_master_invoiceNumber",
+            "unique": true,
+            "columnNames": [
+              "invoiceNumber"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_invoice_master_invoiceNumber` ON `${TABLE_NAME}` (`invoiceNumber`)"
+          }
+        ]
+      },
+      {
+        "tableName": "payment_batch_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `studentId` INTEGER, `batchDate` TEXT NOT NULL, `notes` TEXT, `isArchived` INTEGER NOT NULL DEFAULT 0, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "studentId",
+            "columnName": "studentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "batchDate",
+            "columnName": "batchDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "isArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_payment_batch_master_studentId",
+            "unique": false,
+            "columnNames": [
+              "studentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_payment_batch_master_studentId` ON `${TABLE_NAME}` (`studentId`)"
+          },
+          {
+            "name": "index_payment_batch_master_batchDate",
+            "unique": false,
+            "columnNames": [
+              "batchDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_payment_batch_master_batchDate` ON `${TABLE_NAME}` (`batchDate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "reschedule_master",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL, `title` TEXT, `newDate` TEXT NOT NULL, `newStartTime` TEXT NOT NULL, `newDurationMinutes` INTEGER NOT NULL, `notes` TEXT, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "newDate",
+            "columnName": "newDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newStartTime",
+            "columnName": "newStartTime",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newDurationMinutes",
+            "columnName": "newDurationMinutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "lastModified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "reschedule_master_lessons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`masterId` INTEGER NOT NULL, `lessonId` INTEGER NOT NULL, PRIMARY KEY(`masterId`, `lessonId`))",
+        "fields": [
+          {
+            "fieldPath": "masterId",
+            "columnName": "masterId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lessonId",
+            "columnName": "lessonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "masterId",
+            "lessonId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reschedule_master_lessons_masterId",
+            "unique": false,
+            "columnNames": [
+              "masterId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reschedule_master_lessons_masterId` ON `${TABLE_NAME}` (`masterId`)"
+          },
+          {
+            "name": "index_reschedule_master_lessons_lessonId",
+            "unique": false,
+            "columnNames": [
+              "lessonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reschedule_master_lessons_lessonId` ON `${TABLE_NAME}` (`lessonId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1158a0bf33e2ca4e4fe24760183209de')"
+    ]
+  }
 }

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/22.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/22.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ownerId` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1, `lastModified` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -58,7 +58,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/6.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/6.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL, `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL DEFAULT 0.0, `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -24,7 +24,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "isActive",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/7.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/7.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL, `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL DEFAULT 0.0, `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -24,7 +24,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "isActive",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/8.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/8.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -24,7 +24,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/9.json
+++ b/data/schemas/gr.eduinvoice.data.database.EduInvoiceDatabase/9.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "students",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `surname` TEXT NOT NULL DEFAULT '', `parentMobile` TEXT NOT NULL DEFAULT '', `parentEmail` TEXT DEFAULT NULL, `className` TEXT NOT NULL DEFAULT '', `rate` REAL NOT NULL DEFAULT 0.0, `rateType` TEXT NOT NULL DEFAULT 'hourly', `isActive` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -51,7 +51,8 @@
             "fieldPath": "rate",
             "columnName": "rate",
             "affinity": "REAL",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0.0"
           },
           {
             "fieldPath": "rateType",

--- a/data/src/main/java/gr/eduinvoice/data/database/AutoMigrations.kt
+++ b/data/src/main/java/gr/eduinvoice/data/database/AutoMigrations.kt
@@ -37,6 +37,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 )
 class AutoMigration5To6 : AutoMigrationSpec {
     override fun onPostMigrate(db: SupportSQLiteDatabase) {
+        db.execSQL("UPDATE students SET rate = 0.0 WHERE rate IS NULL")
         db.execSQL(
             """
             CREATE TABLE lessons_new (

--- a/data/src/main/java/gr/eduinvoice/data/model/Student.kt
+++ b/data/src/main/java/gr/eduinvoice/data/model/Student.kt
@@ -23,7 +23,8 @@ data class Student(
     val parentEmail: String? = null,
     @ColumnInfo(defaultValue = "''")
     val className: String,
-    val rate: Double,
+    @ColumnInfo(defaultValue = "0.0")
+    val rate: Double = 0.0,
     @ColumnInfo(defaultValue = "'hourly'")
     val rateType: String = RateTypes.HOURLY,
     @ColumnInfo(defaultValue = "1")


### PR DESCRIPTION
## Summary
- set student rate default to 0.0
- backfill null rates during migration
- bump version to 0.29.1

## Testing
- `./gradlew clean` *(fails: New NOT NULL column 'rate' added with no default value specified)*
- `./gradlew :data:assembleDebug` *(fails: New NOT NULL column 'rate' added with no default value specified)*
- `./gradlew assemble` *(fails: New NOT NULL column 'rate' added with no default value specified)*
- `./gradlew test` *(fails: compilation error)
- `./gradlew lintPlainDebug` *(fails: New NOT NULL column 'rate' added with no default value specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c558534990833093dbcea6edc5accf